### PR TITLE
[22473] Switch launch configurations to launch templates

### DIFF
--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -144,24 +144,23 @@ namespace :deploy do
             # Delete old AMI
             info "Starting deleting old AMI: #{old_ami_image_id}"
             ec2.deregister_image({
-                                   image_id: old_ami_image_id,
-                                   dry_run: false,
-                                 })
+              image_id: old_ami_image_id,
+              dry_run: false,
+            })
             info "Finished delete old AMI: #{old_ami_image_id}"
 
             # Create launch configuration
             info "Starting create launch configuration"
             launch_configuration_name = "Autoscale-#{deployment_env}-launch-#{date_now}"
-            autoscaling.create_launch_configuration(
-              {
-                iam_instance_profile: "autoscaling-iam",
-                image_id: new_ami.image_id,
-                instance_type: fetch(:instance_type),
-                launch_configuration_name: launch_configuration_name,
-                security_groups: [
-                  fetch(:security_group),
-                ],
-              })
+            autoscaling.create_launch_configuration({
+              iam_instance_profile: "autoscaling-iam",
+              image_id: new_ami.image_id,
+              instance_type: fetch(:instance_type),
+              launch_configuration_name: launch_configuration_name,
+              security_groups: [
+                fetch(:security_group),
+              ],
+            })
             info "Finished create launch configuration #{launch_configuration_name}"
 
             # List launch configurations
@@ -169,11 +168,10 @@ namespace :deploy do
 
             # Update autoscaling group
             info "Starting updating autoscaling group: #{autoscaling_group_name}, launch configuration name: #{old_launch_configuration}"
-            autoscaling.update_auto_scaling_group(
-              {
-                auto_scaling_group_name: autoscaling_group_name,
-                launch_configuration_name: launch_configuration_name
-              })
+            autoscaling.update_auto_scaling_group({
+              auto_scaling_group_name: autoscaling_group_name,
+              launch_configuration_name: launch_configuration_name
+            })
             info "Finished updating autoscaling group: #{autoscaling_group_name}, launch configuration name: #{launch_configuration_name}"
 
             # Delete old launch configuration

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -116,20 +116,24 @@ namespace :deploy do
                 iam_instance_profile: {
                   name: 'autoscaling-iam'
                 },
-                security_groups: [
+                monitoring: {
+                  enabled: true
+                },
+                security_group_ids: [
                   fetch(:security_group)
-                ]
+                ],
+                ebs_optimized: false
               }
             })
 
             new_template_version_number = resp.launch_template_version.version_number
-            info "Finished create launch template new version #{new_template_version_number}"
+            info "Finished create launch template new version (V. Number: #{new_template_version_number})"
 
             # Update autoscaling group
             info "Setting new version as default in the launch template"
             ec2.modify_launch_template({
               launch_template_id: fetch(:autoscaling_launch_template_id),
-              default_version: new_template_version_number
+              default_version: new_template_version_number.to_s
             })
           else
             # List images

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
### Summary

Se cambia el proceso de autoescalado para usar "Opcionalmente" (por ahora) launch templates en vez de launch configurations. ([mas info en el TP](https://recorrido.tpondemand.com/entity/22473-awsec2-refactor-deploy-para-usar-launch))

**Nota:** Se preserva el proceso antiguo a elección a través de una variable de entorno de forma que podamos revertir el cambio si algo sale mal en producción.

También se subio el número de version a un "minor" para reflejar el nivel del cambio.