### PR TITLE
[36510] Add setting for teleport hostnames to launch templates

### DIFF
--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -122,6 +122,9 @@ namespace :deploy do
                 security_group_ids: [
                   fetch(:security_group)
                 ],
+                metadata_options: {
+                  instance_metadata_tags: "enabled"
+                },
                 ebs_optimized: false
               }
             })

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
   end
 end


### PR DESCRIPTION
### Summary
Agrega el setting de instance metadata tags al proceso de creacion de versions del Launch template para que se identifiquen correctamente las maquinas en teleport

### Revision:
Se hizo un deploy con la rama especifica del repo de capistrano autoscale con el cambio:
**Traza:** https://roxy-ci.recorrido.cl/job/Ibilbidea/job/development%20club%202%20deploy/417/console

Queda habilitado en la version del Launch template la opción necesaria
![image](https://github.com/recorridoCL/capistrano-autoscale/assets/6487835/6b824439-96a0-42ee-ab0d-6b4bdc33b6cb)
