### PR TITLE
[CU-86acy3p92][CU-86acy3p92][v0.4] autoscaled:deploy task (big refactor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,9 @@ bundle exec cap production autoscaled:deploy
 El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal.
 
 ### Blue/green por paridad
-Con 2 o más instances en el target group:
-```bash
-bundle exec cap production autoscaled:deploy
-```
-El wrapper:
+Con 2 o más instances en el target group, el wrapper:
 1) Cuenta instances del target group.
-2) Si hay suficientes, corre waves en secuencia (`blue_green_orders`, default `even` luego `odd`), pasando `INSTANCE_ORDER` a cada wave.
+2) Si hay suficientes, corre waves en secuencia (`blue_green_orders`, default `even` luego `odd`), pasando `INSTANCE_ORDER` a cada wave. Entre cada wave, va deregistrando/registrando las instancias correspondientes.
 3) Al finalizar las waves, opcionalmente ejecuta `deploy:new_ami_configuration` (controlado por `blue_green_create_ami`).
 
 Puedes forzar el orden en runtime:
@@ -90,7 +86,7 @@ INSTANCE_ORDER=odd bundle exec cap production deploy
 - `deploy:new_ami_configuration`: crea AMI desde una instance del ASG, genera nueva versión del Launch Template y la deja como default (requiere `:volume_sizes`, `:instance_type`, `:autoscaling_group_name`).
 
 ## Casos especiales
-- **Una sola instance**: usa `instance_order = 'even'` (default) para incluir el índice 0; el wrapper hará deploy normal (sin waves).
+- **Una sola instance**: usa `instance_order = 'even'` (default) para incluir el índice 0; el wrapper hará deploy normal (sin waves ni deregistro/registro).
 - **Instance extra fuera del ASG (cron/sidekiq) pero en el target group**: se incluye en el conteo y en las waves porque el discovery se basa en el target group.
 - **Orden de waves**: cambia `blue_green_orders` (ej. `%w[even odd]` o sólo `%w[even]` si quieres evitar un segundo wave en single-node).
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,98 @@
 # Capistrano::Autoscale
-Short description and motivation.
 
-## Usage
-How to use my plugin.
+Herramientas para deploys con Capistrano sobre Auto Scaling Groups en AWS, usando el target group como fuente de servers y soportando deploy normal o blue/green (por paridad `even/odd`).
 
-## Installation
-Add this line to your application's Gemfile:
+## Instalación
 
+En tu `Gemfile`:
 ```ruby
 gem 'capistrano-autoscale'
 ```
-
-And then execute:
+Luego:
 ```bash
-$ bundle
+bundle install
 ```
 
-Or install it yourself as:
-```bash
-$ gem install capistrano-autoscale
+## Configuración mínima (Capistrano)
+
+En `Capfile` (si no lo tienes ya):
+```ruby
+require 'capistrano/autoscale'
 ```
 
-## Contributing
-Contribution directions go here.
+En `config/deploy.rb` (variables comunes):
+```ruby
+set :aws_region, ENV.fetch('AWS_REGION')                             # required;
+set :aws_access_owner_id, ENV.fetch('AWS_ACCESS_KEY_ID')             # required;
+set :aws_secret_owner_access_key, ENV.fetch('AWS_SECRET_ACCESS_KEY') # required;
+set :autoscaling_group_name, ENV.fetch('AUTOSCALING_GROUP_NAME')     # required;
+set :instance_order, 'even'          # default; puede ser 'odd' para la otra mitad
+set :blue_green_min_instances, 2     # default; mínimo para habilitar blue/green
+set :blue_green_orders, %w[even odd] # default; secuencia de waves; puedes cambiarla
+set :blue_green_create_ami, true     # default; si quieres crear AMI al final del blue/green
+```
 
-## License
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+En `config/deploy/production.rb` (ejemplo):
+```ruby
+set :rails_env, 'production'      # usualmente ya está seteado
+set :deployment_env, 'production' # required; usado para nombrar la AMI, versión y descripciones
+set :instance_type, 't3.medium'   # required; usar la de las instancias del proyecto
+set :volume_sizes, [30, 20]       # required; raíz y data, usados al crear AMI
+set :deploy_user, 'ubuntu'        # required;
+
+# Llamar esta función en el stage file para cargar servers antes del deploy
+setup_servers
+```
+
+## Cómo se descubren los servers
+
+- La gema toma el ARN del target group desde el Auto Scaling Group y lista los targets healthy (`describe_target_health`).
+- Cualquier instance registrada en el target group se incluye, aunque no pertenezca formalmente al ASG (útil para instancias como la cron, o instancias de sidekiq (posiblemente)).
+- La paridad `even/odd` se aplica por índice del listado ordenado, comenzando en 0.
+
+## Deploys
+El deploy funciona a través de un único wrapper task:
+```bash
+bundle exec cap production autoscaled:deploy
+```
+
+Este se adecua a cada caso como vemos a continuación:
+
+### Deploy normal (sin blue/green, menos del "mínimo" de instancias)
+Cuando el target group tiene una sola instance (o cuando no se cumple `blue_green_min_instances`):
+```bash
+bundle exec cap production autoscaled:deploy
+```
+El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal.
+
+### Blue/green por paridad
+Con 2 o más instances en el target group:
+```bash
+bundle exec cap production autoscaled:deploy
+```
+El wrapper:
+1) Cuenta instances del target group.
+2) Si hay suficientes, corre waves en secuencia (`blue_green_orders`, default `even` luego `odd`), pasando `INSTANCE_ORDER` a cada wave.
+3) Al finalizar las waves, opcionalmente ejecuta `deploy:new_ami_configuration` (controlado por `blue_green_create_ami`).
+
+Puedes forzar el orden en runtime:
+```bash
+INSTANCE_ORDER=odd bundle exec cap production deploy
+```
+(Por si quieres correr sólo una wave manualmente.)
+
+## Tareas incluidas
+
+- `autoscaled:deploy`: wrapper que decide normal vs. blue/green según el conteo del target group.
+- `autoscaled:blue_green_deploy`: ejecuta las waves en el orden configurado y luego la creación de AMI opcional.
+- `deploy:register_instances_in_load_balancer`: registra los `:instances` actuales en el target group.
+- `deploy:deregister_instances_from_load_balancer`: los saca del target group.
+- `deploy:new_ami_configuration`: crea AMI desde una instance del ASG, genera nueva versión del Launch Template y la deja como default (requiere `:volume_sizes`, `:instance_type`, `:autoscaling_group_name`).
+
+## Casos especiales
+- **Una sola instance**: usa `instance_order = 'even'` (default) para incluir el índice 0; el wrapper hará deploy normal (sin waves).
+- **Instance extra fuera del ASG (cron/sidekiq) pero en el target group**: se incluye en el conteo y en las waves porque el discovery se basa en el target group.
+- **Orden de waves**: cambia `blue_green_orders` (ej. `%w[even odd]` o sólo `%w[even]` si quieres evitar un segundo wave en single-node).
+
+## Licencia
+MIT. See [MIT License](http://opensource.org/licenses/MIT).

--- a/bin/test
+++ b/bin/test
@@ -8,4 +8,4 @@ Rails::TestUnitReporter.executable = 'bin/test'
 
 Minitest.run_via = :rails
 
-require "active_support/testing/autorun"
+require 'active_support/testing/autorun'

--- a/capistrano-autoscale.gemspec
+++ b/capistrano-autoscale.gemspec
@@ -1,23 +1,23 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 # Maintain your gem's version:
-require "capistrano/autoscale/version"
+require 'capistrano/autoscale/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "capistrano-autoscale"
+  s.name        = 'capistrano-autoscale'
   s.version     = Capistrano::Autoscale::VERSION
-  s.authors     = ["recorridoCl"]
-  s.email       = ["benjamin@recorrido.cl"]
-  s.homepage    = "https://www.github.com/recorridoCL/capistrano-autoscale"
-  s.summary     = "Custom gem for even / odd rolling deployments using capistrano and amazon web services (autoscaling and target group)"
-  s.description = "Custom gem for even / odd rolling deployments using capistrano and amazon web services (autoscaling and target group)"
-  s.license     = "MIT"
+  s.authors     = ['recorridoCl']
+  s.email       = ['barbara@recorrido.cl']
+  s.homepage    = 'https://www.github.com/recorridoCL/capistrano-autoscale'
+  s.summary     = 'Custom gem for even / odd rolling deployments using capistrano and amazon web services (autoscaling and target group)'
+  s.description = 'Custom gem for even / odd rolling deployments using capistrano and amazon web services (autoscaling and target group)'
+  s.license     = 'MIT'
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency "capistrano", ">= 3.8"
-  s.add_dependency "aws-sdk-ec2", ">= 1.23.0"
-  s.add_dependency "aws-sdk-elasticloadbalancingv2", ">= 1.6.0"
-  s.add_dependency "aws-sdk-autoscaling", ">= 1.4.0"
+  s.add_dependency 'aws-sdk-autoscaling', '>= 1.4.0'
+  s.add_dependency 'aws-sdk-ec2', '>= 1.23.0'
+  s.add_dependency 'aws-sdk-elasticloadbalancingv2', '>= 1.6.0'
+  s.add_dependency 'capistrano', '>= 3.8'
 end

--- a/lib/capistrano/autoscale.rb
+++ b/lib/capistrano/autoscale.rb
@@ -7,19 +7,23 @@ require 'capistrano/autoscale/helpers/aws_utils'
 load File.expand_path('../autoscale/tasks/autoscale.rake', __FILE__)
 
 def setup_servers
-  puts "Search instances to deploy"
-  ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_ec2_instances(fetch(:instance_order))
+  puts 'Set up instances to deploy for capistrano configuration'
+  instance_order = ENV['INSTANCE_ORDER'] || fetch(:instance_order, 'even')
+  ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_ec2_instances(instance_order)
   aws_deploy_user = fetch(:deploy_user)
-  set :instances, ec2_instances.map {|i| {id: i[:instance_id]}}
-  ec2_instances.each {|instance|
-    if ec2_instances.first == instance
-      roles = %w{web app db}
-      server instance[:private_ip_address], user: aws_deploy_user, roles:  roles, primary: true
-      puts "First Server: #{instance[:private_ip_address]} - #{roles}, instance_id: #{instance[:instance_id]}"
-    else
-      roles = %w{web app}
-      server instance[:private_ip_address], user: aws_deploy_user, roles: roles
-      puts "Server: #{instance[:private_ip_address]} - #{roles}, instance_id: #{instance[:instance_id]}"
-    end
-  }
+
+  # Set up :instances being used (used for deregistering and registering instances in load balancer)
+  set :instances, ec2_instances.map { |instance| { id: instance[:instance_id] } }
+
+  ec2_instances.each_with_index do |instance, index|
+    primary = index.zero?
+    server_config = {
+      user: aws_deploy_user,
+      roles: primary ? %w[web app db] : %w[web app]
+    }
+    server_config[:primary] = primary if primary
+
+    server instance[:private_ip_address], server_config
+    puts "#{primary ? 'First Server' : 'Server'}: #{instance[:private_ip_address]} - #{server_config[:roles]}, id: #{instance[:instance_id]}"
+  end
 end

--- a/lib/capistrano/autoscale.rb
+++ b/lib/capistrano/autoscale.rb
@@ -3,6 +3,7 @@ require 'aws-sdk-elasticloadbalancingv2'
 require 'aws-sdk-autoscaling'
 require 'capistrano/all'
 require 'capistrano/autoscale/helpers/aws_utils'
+require 'capistrano/autoscale/helpers/local_runner'
 
 load File.expand_path('../autoscale/tasks/autoscale.rake', __FILE__)
 

--- a/lib/capistrano/autoscale.rb
+++ b/lib/capistrano/autoscale.rb
@@ -6,7 +6,6 @@ require 'capistrano/autoscale/helpers/aws_utils'
 
 load File.expand_path('../autoscale/tasks/autoscale.rake', __FILE__)
 
-
 def setup_servers
   puts "Search instances to deploy"
   ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_ec2_instances(fetch(:instance_order))

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -45,6 +45,85 @@ module Capistrano
         selected_instances
       end
 
+      def self.create_ami(ec2:, instance_id:, volume_sizes:, deployment_env:, date_now:)
+        ec2.create_image(
+          block_device_mappings: [
+            {
+              device_name: '/dev/sda1',
+              ebs: {
+                encrypted: false,
+                delete_on_termination: true,
+                volume_size: volume_sizes[0],
+                volume_type: 'gp2'
+              }
+            },
+            {
+              device_name: '/dev/sdf',
+              ebs: {
+                encrypted: false,
+                delete_on_termination: true,
+                volume_size: volume_sizes[1],
+                volume_type: 'gp2'
+              }
+            }
+          ],
+          description: "#{deployment_env} autoscale with ebs termination #{date_now}",
+          dry_run: false,
+          instance_id: instance_id,
+          name: "#{deployment_env}-autoscale #{date_now}",
+          no_reboot: true
+        )
+      end
+
+      def self.create_launch_template_version_from_ami(ec2:, launch_template_id:, image_id:, instance_type:, deployment_env:, date_now:)
+        version_name = "Autoscale-#{deployment_env}-template-version-#{date_now}"
+
+        launch_template_single_version = ec2.describe_launch_template_versions(
+          launch_template_id: launch_template_id,
+          versions: ['$Default']
+        ).launch_template_versions.first
+
+        security_groups = launch_template_single_version.launch_template_data.security_group_ids
+        iam_instance_profile_name = launch_template_single_version.launch_template_data.iam_instance_profile&.name
+        key_name = launch_template_single_version.launch_template_data.key_name
+        tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map { |ts| ts.to_h }
+
+        lt_request_params = {
+          launch_template_id: launch_template_id,
+          version_description: version_name,
+          launch_template_data: {
+            image_id: image_id,
+            instance_type: instance_type,
+            iam_instance_profile: {
+              name: iam_instance_profile_name || 'autoscaling-iam'
+            },
+            monitoring: {
+              enabled: true
+            },
+            security_group_ids: security_groups,
+            metadata_options: {
+              instance_metadata_tags: 'enabled'
+            },
+            ebs_optimized: false
+          }
+        }
+        lt_request_params[:launch_template_data][:key_name] = key_name if key_name
+        lt_request_params[:launch_template_data][:tag_specifications] = tag_specs if tag_specs.any?
+
+        resp = ec2.create_launch_template_version(lt_request_params)
+        new_template_version_number = resp.launch_template_version.version_number
+
+        puts "- launch template id: #{launch_template_single_version.launch_template_id}"
+        puts "- launch template chosen version number: #{launch_template_single_version.version_number}"
+        puts "- launch template versions security groups: #{Array(security_groups).join(', ')}"
+        puts "- launch template versions IAM profile name: #{iam_instance_profile_name}"
+        puts "- launch template versions key name: #{key_name}"
+        puts "- launch template params: #{lt_request_params.to_h}"
+        puts "Finished create launch template new version (V. Number: #{new_template_version_number})"
+
+        new_template_version_number
+      end
+
       def self.extract_launch_template_id(autoscaling_group)
         launch_template_id =
           if autoscaling_group.launch_template

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -48,11 +48,11 @@ module Capistrano
       def self.extract_launch_template_id(autoscaling_group)
         launch_template_id =
           if autoscaling_group.launch_template
-            puts "Using launch template ID from SDK v1 structure"
+            puts 'Using launch template ID from SDK v1 structure'
             lt = autoscaling_group.launch_template
             lt.launch_template_id || lt['launch_template_id'] || lt[:launch_template_id]
           else
-            puts "Using launch template ID from capistrano config variable"
+            puts 'Using launch template ID from capistrano config variable'
             fetch(:autoscaling_launch_template_id, nil)
           end
 

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -22,12 +22,16 @@ module Capistrano
         tg_arn = autoscaling_group.target_group_arns&.first
 
         loadbalancer_data = loadbalancer.describe_target_health(target_group_arn: tg_arn)
-        instances_ids = loadbalancer_data.target_health_descriptions.map{|h| h.target.id}.sort
+        instances_ids = loadbalancer_data.target_health_descriptions.map { |h| h.target.id }.sort
         return [] if instances_ids.empty?
 
-        description_instances = ec2.describe_instances({instance_ids: instances_ids}).reservations
+        description_instances = ec2.describe_instances(instance_ids: instances_ids).reservations
 
-        instances = description_instances.map{|h| h.instances.map {|i| {instance_id: i.instance_id, private_ip_address: i.private_ip_address}}}.flatten
+        instances = description_instances.map do |h|
+          h.instances.map do |i|
+            { instance_id: i.instance_id, private_ip_address: i.private_ip_address }
+          end
+        end.flatten
         instances_by_id = instances.each_with_object({}) do |instance, memo|
           memo[instance[:instance_id]] = instance
         end

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -24,6 +24,32 @@ module Capistrano
 
         instances
       end
+
+      def self.extract_launch_template_id(autoscaling_group)
+        # Extract launch template ID from autoscaling group
+        launch_template_id =
+          if autoscaling_group.launch_template
+            puts "Using launch template ID from SDK v1 structure"
+            # Try method access first (SDK v1 structure)
+            lt = autoscaling_group.launch_template
+            lt.launch_template_id || lt['launch_template_id'] || lt[:launch_template_id]
+          elsif autoscaling_group['launch_template']
+            # Fallback to hash access
+            puts "Using launch template ID from hash structure"
+            lt = autoscaling_group['launch_template']
+            lt['launch_template_id'] || lt[:launch_template_id]
+          else
+            # Fallback to config variable if not found in ASG
+            puts "Using launch template ID from capistrano config variable"
+            fetch(:autoscaling_launch_template_id, nil)
+          end
+
+        if launch_template_id.nil?
+          raise 'Launch template ID not found in Auto Scaling Group and not provided via :autoscaling_launch_template_id config'
+        end
+
+        launch_template_id
+      end
     end
   end
 end

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -2,9 +2,17 @@ module Capistrano
   module Autoscale
     class AwsUtils
       include Capistrano::DSL
+      def self.configure_aws(region:, access_key:, secret_key:)
+        ::Aws.config[:region] = region
+        ::Aws.config[:credentials] = ::Aws::Credentials.new(access_key, secret_key)
+      end
+
       def self.fetch_ec2_instances(type)
-        ::Aws.config[:region] = fetch(:aws_region)
-        ::Aws.config[:credentials] = ::Aws::Credentials.new(fetch(:aws_access_owner_id), fetch(:aws_secret_owner_access_key))
+        configure_aws(
+          region: fetch(:aws_region),
+          access_key: fetch(:aws_access_owner_id),
+          secret_key: fetch(:aws_secret_owner_access_key)
+        )
 
         loadbalancer = ::Aws::ElasticLoadBalancingV2::Client.new
         ec2 = ::Aws::EC2::Client.new

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -7,7 +7,7 @@ module Capistrano
         ::Aws.config[:credentials] = ::Aws::Credentials.new(access_key, secret_key)
       end
 
-      def self.fetch_ec2_instances(type)
+      def self.fetch_all_ec2_instances
         configure_aws(
           region: fetch(:aws_region),
           access_key: fetch(:aws_access_owner_id),
@@ -22,17 +22,27 @@ module Capistrano
         tg_arn = autoscaling_group.target_group_arns&.first
 
         loadbalancer_data = loadbalancer.describe_target_health(target_group_arn: tg_arn)
+        instances_ids = loadbalancer_data.target_health_descriptions.map{|h| h.target.id}.sort
+        return [] if instances_ids.empty?
 
-        instances_ids = loadbalancer_data.target_health_descriptions.map { |h| h.target.id }.sort
+        description_instances = ec2.describe_instances({instance_ids: instances_ids}).reservations
 
-        type_instances = instances_ids.values_at(*instances_ids.each_index.select { |i| i.send("#{type}?") })
-        description_instances = ec2.describe_instances({ instance_ids: type_instances }).reservations
+        instances = description_instances.map{|h| h.instances.map {|i| {instance_id: i.instance_id, private_ip_address: i.private_ip_address}}}.flatten
+        instances_by_id = instances.each_with_object({}) do |instance, memo|
+          memo[instance[:instance_id]] = instance
+        end
 
-        instances = description_instances.map { |h| h.instances.map { |i| { instance_id: i.instance_id, private_ip_address: i.private_ip_address } } }.flatten
+        instances_ids.map { |id| instances_by_id[id] }.compact
+      end
 
-        puts "Found #{type} #{instances.count} servers (#{instances.join(',')})"
+      def self.fetch_ec2_instances(type)
+        instances = fetch_all_ec2_instances
 
-        instances
+        selected_instances = instances.values_at(* instances.each_index.select {|i| i.send("#{type}?")})
+
+        puts "Found #{type} #{selected_instances.count} servers (#{selected_instances.join(',')})"
+
+        selected_instances
       end
 
       def self.extract_launch_template_id(autoscaling_group)

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -50,6 +50,20 @@ module Capistrano
 
         launch_template_id
       end
+
+      def self.fetch_autoscaling_group(autoscaling_group_name)
+        autoscaling = ::Aws::AutoScaling::Client.new
+        response = autoscaling.describe_auto_scaling_groups(
+          auto_scaling_group_names: [autoscaling_group_name]
+        )
+        autoscaling_group = response.auto_scaling_groups&.first
+
+        if autoscaling_group.nil?
+          raise "Auto Scaling Group '#{autoscaling_group_name}' not found"
+        end
+
+        autoscaling_group
+      end
     end
   end
 end

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -91,6 +91,7 @@ module Capistrano
         iam_instance_profile_name = launch_template_single_version.launch_template_data.iam_instance_profile&.name
         key_name = launch_template_single_version.launch_template_data.key_name
         tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map { |ts| ts.to_h }
+        user_data = launch_template_single_version.launch_template_data.user_data
 
         lt_request_params = {
           launch_template_id: launch_template_id,
@@ -108,7 +109,8 @@ module Capistrano
             metadata_options: {
               instance_metadata_tags: 'enabled'
             },
-            ebs_optimized: false
+            ebs_optimized: false,
+            user_data: user_data
           }
         }
         lt_request_params[:launch_template_data][:key_name] = key_name if key_name

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -18,15 +18,15 @@ module Capistrano
         ec2 = ::Aws::EC2::Client.new
 
         loadbalancer_data = loadbalancer.describe_target_health({
-                                                                    target_group_arn: fetch(:autoscaling_target_group_arn)
-                                                                })
+          target_group_arn: fetch(:autoscaling_target_group_arn)
+        })
 
-        instances_ids = loadbalancer_data.target_health_descriptions.map{|h| h.target.id}.sort
+        instances_ids = loadbalancer_data.target_health_descriptions.map { |h| h.target.id }.sort
 
-        type_instances = instances_ids.values_at(* instances_ids.each_index.select {|i| i.send("#{type}?")})
-        description_instances = ec2.describe_instances({instance_ids: type_instances}).reservations
+        type_instances = instances_ids.values_at(*instances_ids.each_index.select { |i| i.send("#{type}?") })
+        description_instances = ec2.describe_instances({ instance_ids: type_instances }).reservations
 
-        instances = description_instances.map{|h| h.instances.map {|i| {instance_id: i.instance_id, private_ip_address: i.private_ip_address}}}.flatten
+        instances = description_instances.map { |h| h.instances.map { |i| { instance_id: i.instance_id, private_ip_address: i.private_ip_address } } }.flatten
 
         puts "Found #{type} #{instances.count} servers (#{instances.join(',')})"
 

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -17,9 +17,11 @@ module Capistrano
         loadbalancer = ::Aws::ElasticLoadBalancingV2::Client.new
         ec2 = ::Aws::EC2::Client.new
 
-        loadbalancer_data = loadbalancer.describe_target_health({
-          target_group_arn: fetch(:autoscaling_target_group_arn)
-        })
+        autoscaling_group_name = fetch(:autoscaling_group_name)
+        autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
+        tg_arn = autoscaling_group.target_group_arns&.first
+
+        loadbalancer_data = loadbalancer.describe_target_health(target_group_arn: tg_arn)
 
         instances_ids = loadbalancer_data.target_health_descriptions.map { |h| h.target.id }.sort
 
@@ -34,26 +36,18 @@ module Capistrano
       end
 
       def self.extract_launch_template_id(autoscaling_group)
-        # Extract launch template ID from autoscaling group
         launch_template_id =
           if autoscaling_group.launch_template
             puts "Using launch template ID from SDK v1 structure"
-            # Try method access first (SDK v1 structure)
             lt = autoscaling_group.launch_template
             lt.launch_template_id || lt['launch_template_id'] || lt[:launch_template_id]
-          elsif autoscaling_group['launch_template']
-            # Fallback to hash access
-            puts "Using launch template ID from hash structure"
-            lt = autoscaling_group['launch_template']
-            lt['launch_template_id'] || lt[:launch_template_id]
           else
-            # Fallback to config variable if not found in ASG
             puts "Using launch template ID from capistrano config variable"
             fetch(:autoscaling_launch_template_id, nil)
           end
 
         if launch_template_id.nil?
-          raise 'Launch template ID not found in Auto Scaling Group and not provided via :autoscaling_launch_template_id config'
+          raise 'Launch template ID not found neither in ASG or via :autoscaling_launch_template_id config'
         end
 
         launch_template_id

--- a/lib/capistrano/autoscale/helpers/local_runner.rb
+++ b/lib/capistrano/autoscale/helpers/local_runner.rb
@@ -1,0 +1,15 @@
+module Capistrano
+  module Autoscale
+    class LocalRunner
+      def self.run_cap_locally(stage:, task_name:, instance_order: nil)
+        cmd = ['bundle', 'exec', 'cap', stage.to_s, task_name.to_s]
+        env = {}
+        env['INSTANCE_ORDER'] = instance_order.to_s if instance_order
+
+        puts "Running locally: #{env.empty? ? '' : "INSTANCE_ORDER=#{instance_order} "}#{cmd.join(' ')}"
+        success = system(env, *cmd)
+        raise "Local command failed: #{cmd.join(' ')}" unless success
+      end
+    end
+  end
+end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -101,106 +101,59 @@ namespace :deploy do
               })
           info "Finished create AMI #{new_ami.image_id}"
 
-          launch_templates_enabled = fetch(:autoscaling_launch_templates_enabled)
+          # Create launch template version from new AMI
+          info "Starting create launch template new version"
+          version_name = "Autoscale-#{deployment_env}-template-version-#{date_now}"
 
-          if launch_templates_enabled
-            # Create launch template version from new AMI
-            info "Starting create launch template new version"
-            version_name = "Autoscale-#{deployment_env}-template-version-#{date_now}"
+          info "Getting launch template data..."
+          launch_template_single_version = ec2.describe_launch_template_versions({
+            launch_template_id: fetch(:autoscaling_launch_template_id),
+            versions: ["$Default"]
+          }).launch_template_versions.first
+          info "- launch template id: #{launch_template_single_version.launch_template_id}"
+          info "- launch template chosen version number: #{launch_template_single_version.version_number}"
+          security_groups = launch_template_single_version.launch_template_data.security_group_ids
+          info "- launch template versions security groups: #{security_groups.join(', ')}"
+          iam_instance_profile_name = launch_template_single_version.launch_template_data.iam_instance_profile&.name
+          info "- launch template versions IAM profile name: #{iam_instance_profile_name}"
+          key_name = launch_template_single_version.launch_template_data.key_name
+          info "- launch template versions key name: #{key_name}"
+          tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map {|ts| ts.to_h}
 
-            info "Getting launch template data..."
-            launch_template_single_version = ec2.describe_launch_template_versions({
-              launch_template_id: fetch(:autoscaling_launch_template_id),
-              versions: ["$Default"]
-            }).launch_template_versions.first
-            info "- launch template id: #{launch_template_single_version.launch_template_id}"
-            info "- launch template chosen version number: #{launch_template_single_version.version_number}"
-            security_groups = launch_template_single_version.launch_template_data.security_group_ids
-            info "- launch template versions security groups: #{security_groups.join(', ')}"
-            iam_instance_profile_name = launch_template_single_version.launch_template_data.iam_instance_profile&.name
-            info "- launch template versions IAM profile name: #{iam_instance_profile_name}"
-            key_name = launch_template_single_version.launch_template_data.key_name
-            info "- launch template versions key name: #{key_name}"
-            tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map {|ts| ts.to_h}
-
-            lt_request_params = {
-              launch_template_id: fetch(:autoscaling_launch_template_id),
-              version_description: version_name,
-              launch_template_data: {
-                image_id: new_ami.image_id,
-                instance_type: fetch(:instance_type),
-                iam_instance_profile: {
-                  name: iam_instance_profile_name || "autoscaling-iam"
-                },
-                monitoring: {
-                  enabled: true
-                },
-                security_group_ids: security_groups,
-                metadata_options: {
-                  instance_metadata_tags: "enabled"
-                },
-                ebs_optimized: false
-              }
-            }
-            lt_request_params[:launch_template_data][:key_name] = key_name if key_name
-            lt_request_params[:launch_template_data][:tag_specifications] = tag_specs if tag_specs.any?
-            info "- launch template params: #{lt_request_params.to_h}"
-
-            resp = ec2.create_launch_template_version(lt_request_params)
-
-            new_template_version_number = resp.launch_template_version.version_number
-            info "Finished create launch template new version (V. Number: #{new_template_version_number})"
-
-            # Update autoscaling group
-            info "Setting new version as default in the launch template"
-            ec2.modify_launch_template({
-              launch_template_id: fetch(:autoscaling_launch_template_id),
-              default_version: new_template_version_number.to_s
-            })
-          else
-            # List images
-            old_amis = ec2.describe_images({owners: ['824916716342']}).images.select {|s| s['name'].downcase.include?("#{deployment_env}-autoscale")}.map {|h| {name: h['name'], image_id: h['image_id']}}
-            old_ami = old_amis.sort_by { |h| h[:name] }.first
-            old_ami_image_id = old_ami[:image_id]
-
-            # Delete old AMI
-            info "Starting deleting old AMI: #{old_ami_image_id}"
-            ec2.deregister_image({
-              image_id: old_ami_image_id,
-              dry_run: false,
-            })
-            info "Finished delete old AMI: #{old_ami_image_id}"
-
-            # Create launch configuration
-            info "Starting create launch configuration"
-            launch_configuration_name = "Autoscale-#{deployment_env}-launch-#{date_now}"
-            autoscaling.create_launch_configuration({
-              iam_instance_profile: "autoscaling-iam",
+          lt_request_params = {
+            launch_template_id: fetch(:autoscaling_launch_template_id),
+            version_description: version_name,
+            launch_template_data: {
               image_id: new_ami.image_id,
               instance_type: fetch(:instance_type),
-              launch_configuration_name: launch_configuration_name,
-              security_groups: [
-                fetch(:security_group),
-              ],
-            })
-            info "Finished create launch configuration #{launch_configuration_name}"
+              iam_instance_profile: {
+                name: iam_instance_profile_name || "autoscaling-iam"
+              },
+              monitoring: {
+                enabled: true
+              },
+              security_group_ids: security_groups,
+              metadata_options: {
+                instance_metadata_tags: "enabled"
+              },
+              ebs_optimized: false
+            }
+          }
+          lt_request_params[:launch_template_data][:key_name] = key_name if key_name
+          lt_request_params[:launch_template_data][:tag_specifications] = tag_specs if tag_specs.any?
+          info "- launch template params: #{lt_request_params.to_h}"
 
-            # List launch configurations
-            old_launch_configuration = autoscaling.describe_launch_configurations.launch_configurations.select {|h| h['image_id'] == old_ami_image_id}[0].launch_configuration_name
+          resp = ec2.create_launch_template_version(lt_request_params)
 
-            # Update autoscaling group
-            info "Starting updating autoscaling group: #{autoscaling_group_name}, launch configuration name: #{old_launch_configuration}"
-            autoscaling.update_auto_scaling_group({
-              auto_scaling_group_name: autoscaling_group_name,
-              launch_configuration_name: launch_configuration_name
-            })
-            info "Finished updating autoscaling group: #{autoscaling_group_name}, launch configuration name: #{launch_configuration_name}"
+          new_template_version_number = resp.launch_template_version.version_number
+          info "Finished create launch template new version (V. Number: #{new_template_version_number})"
 
-            # Delete old launch configuration
-            info "Starting removing old launch configuration #{old_launch_configuration}"
-            autoscaling.delete_launch_configuration({launch_configuration_name: old_launch_configuration})
-            info "Finished removing old launch configuration #{old_launch_configuration}"
-          end
+          # Update autoscaling group
+          info "Setting new version as default in the launch template"
+          ec2.modify_launch_template({
+            launch_template_id: fetch(:autoscaling_launch_template_id),
+            default_version: new_template_version_number.to_s
+          })
         end
       end
     end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -14,7 +14,7 @@ namespace :deploy do
 
           autoscaling_group_name = fetch(:autoscaling_group_name)
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
-          tg_arn = autoscaling_group.target_group_arn
+          tg_arn = autoscaling_group.target_group_arns.first
 
           if tg_arn.present?
             info "using target group arn from autoscaling group: #{autoscaling_group_name}"
@@ -48,7 +48,7 @@ namespace :deploy do
 
           autoscaling_group_name = fetch(:autoscaling_group_name)
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
-          tg_arn = autoscaling_group.target_group_arn
+          tg_arn = autoscaling_group.target_group_arns.first
 
           if tg_arn.present?
             info "using target group arn from autoscaling group: #{autoscaling_group_name}"

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -176,12 +176,12 @@ namespace :autoscaled do
     instance_count = ec2_instances.count
 
     if instance_count < min_for_blue_green
-      info "ASG #{asg_name} has #{instance_count} instance(s) (min=#{min_for_blue_green}). Running normal deploy on #{stage}."
+      puts "ASG #{asg_name} has #{instance_count} instance(s) (min=#{min_for_blue_green}). Running normal deploy on #{stage}."
       invoke 'deploy' # regular deploy for this env
       next
     end
 
-    info "ASG #{asg_name} has #{instance_count} instances, running blue/green deploy."
+    puts "ASG #{asg_name} has #{instance_count} instances, running blue/green deploy."
     invoke 'autoscaled:blue_green_deploy'
   end
 
@@ -192,12 +192,12 @@ namespace :autoscaled do
     # Orders to deploy in sequence (default: even then odd)
     orders = fetch(:blue_green_orders, %w[even odd])
 
-    info "Starting blue/green deploy waves for stage #{stage} (orders: #{orders.join(', ')})"
+    puts "Starting blue/green deploy waves for stage #{stage} (orders: #{orders.join(', ')})"
 
     orders.each do |order|
-      info "Deploying #{order} instances..."
+      puts "Deploying #{order} instances..."
 
-      info "Deregistering #{order} instances from load balancer..."
+      puts "Deregistering #{order} instances from load balancer..."
       run_locally do
         with 'INSTANCE_ORDER' => order do
           execute :bundle, :exec, :cap, stage, 'deploy:deregister_instances_from_load_balancer'
@@ -210,7 +210,7 @@ namespace :autoscaled do
         end
       end
 
-      info "Registering #{order} instances back into load balancer..."
+      puts "Registering #{order} instances back into load balancer..."
       run_locally do
         with 'INSTANCE_ORDER' => order do
           execute :bundle, :exec, :cap, stage, 'deploy:register_instances_in_load_balancer'
@@ -220,12 +220,12 @@ namespace :autoscaled do
 
     # Optionally bake a new AMI after both waves
     if fetch(:blue_green_create_ami, true)
-      info "Creating new AMI after blue/green deploy..."
+      puts "Creating new AMI after blue/green deploy..."
       run_locally do
         execute :bundle, :exec, :cap, stage, 'deploy:new_ami_configuration'
       end
     end
 
-    info "Blue/green deploy finished for #{stage}."
+    puts "Blue/green deploy finished for #{stage}."
   end
 end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -4,8 +4,11 @@ namespace :deploy do
     on roles(:db) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          ::Aws.config[:region] = fetch(:aws_region)
-          ::Aws.config[:credentials] = ::Aws::Credentials.new(fetch(:aws_access_owner_id), fetch(:aws_secret_owner_access_key))
+          Capistrano::Autoscale::AwsUtils.configure_aws(
+            region: fetch(:aws_region),
+            access_key: fetch(:aws_access_owner_id),
+            secret_key: fetch(:aws_secret_owner_access_key)
+          )
 
           loadbalancer = ::Aws::ElasticLoadBalancingV2::Client.new
 
@@ -35,8 +38,11 @@ namespace :deploy do
     on roles(:db) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          ::Aws.config[:region] = fetch(:aws_region)
-          ::Aws.config[:credentials] = ::Aws::Credentials.new(fetch(:aws_access_owner_id), fetch(:aws_secret_owner_access_key))
+          Capistrano::Autoscale::AwsUtils.configure_aws(
+            region: fetch(:aws_region),
+            access_key: fetch(:aws_access_owner_id),
+            secret_key: fetch(:aws_secret_owner_access_key)
+          )
 
           loadbalancer = ::Aws::ElasticLoadBalancingV2::Client.new
 
@@ -66,8 +72,11 @@ namespace :deploy do
       within release_path do
         with rails_env: fetch(:rails_env) do
           deployment_env = fetch(:deployment_env)
-          ::Aws.config[:region] = fetch(:aws_region)
-          ::Aws.config[:credentials] = ::Aws::Credentials.new(fetch(:aws_access_owner_id), fetch(:aws_secret_owner_access_key))
+          Capistrano::Autoscale::AwsUtils.configure_aws(
+            region: fetch(:aws_region),
+            access_key: fetch(:aws_access_owner_id),
+            secret_key: fetch(:aws_secret_owner_access_key)
+          )
 
           date_now = Time.now.strftime('%d-%m-%Y %H.%M')
 

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -61,13 +61,36 @@ namespace :deploy do
           autoscaling = ::Aws::AutoScaling::Client.new
           autoscaling_group_name = fetch(:autoscaling_group_name)
 
-          instances = autoscaling.describe_auto_scaling_groups(
+          autoscaling_group_response = autoscaling.describe_auto_scaling_groups(
               {
                   auto_scaling_group_names: [
                       autoscaling_group_name
                   ]
               }
-          ).auto_scaling_groups[0].instances.map {|h| h['instance_id']}
+          )
+          autoscaling_group = autoscaling_group_response.auto_scaling_groups[0]
+          instances = autoscaling_group.instances.map {|h| h['instance_id']}
+
+          # Extract launch template ID from autoscaling group
+          launch_template_id =
+            if autoscaling_group.launch_template
+              # Try method access first (SDK v1 structure)
+              lt = autoscaling_group.launch_template
+              lt.launch_template_id || lt['launch_template_id'] || lt[:launch_template_id]
+            elsif autoscaling_group['launch_template']
+              # Fallback to hash access
+              lt = autoscaling_group['launch_template']
+              lt['launch_template_id'] || lt[:launch_template_id]
+            else
+              # Fallback to config variable if not found in ASG
+              fetch(:autoscaling_launch_template_id, nil)
+            end
+
+          if launch_template_id.nil?
+            raise "Launch template ID not found in Auto Scaling Group '#{autoscaling_group_name}' and not provided via :autoscaling_launch_template_id config"
+          end
+
+          info "Using launch template ID: #{launch_template_id}"
 
           # Create AMI
           info "Starting creating AMI"
@@ -107,7 +130,7 @@ namespace :deploy do
 
           info "Getting launch template data..."
           launch_template_single_version = ec2.describe_launch_template_versions({
-            launch_template_id: fetch(:autoscaling_launch_template_id),
+            launch_template_id: launch_template_id,
             versions: ["$Default"]
           }).launch_template_versions.first
           info "- launch template id: #{launch_template_single_version.launch_template_id}"
@@ -121,7 +144,7 @@ namespace :deploy do
           tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map {|ts| ts.to_h}
 
           lt_request_params = {
-            launch_template_id: fetch(:autoscaling_launch_template_id),
+            launch_template_id: launch_template_id,
             version_description: version_name,
             launch_template_data: {
               image_id: new_ami.image_id,
@@ -151,7 +174,7 @@ namespace :deploy do
           # Update autoscaling group
           info "Setting new version as default in the launch template"
           ec2.modify_launch_template({
-            launch_template_id: fetch(:autoscaling_launch_template_id),
+            launch_template_id: launch_template_id,
             default_version: new_template_version_number.to_s
           })
         end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -1,5 +1,5 @@
 namespace :deploy do
-  desc "Register instances in load balancer"
+  desc 'Register instances in load balancer'
   task :register_instances_in_load_balancer do
     on roles(:db) do
       within release_path do
@@ -26,7 +26,7 @@ namespace :deploy do
     end
   end
 
-  desc "Deregister instances from load balancer"
+  desc 'Deregister instances from load balancer'
   task :deregister_instances_from_load_balancer do
     on roles(:db) do
       within release_path do
@@ -52,7 +52,7 @@ namespace :deploy do
     end
   end
 
-  desc "New AMI from deploy and associate to scaling group"
+  desc 'New AMI from deploy and associate to scaling group'
   task :new_ami_configuration do
     on roles(:db) do
       within release_path do
@@ -75,7 +75,7 @@ namespace :deploy do
           info "Using launch template ID: #{launch_template_id}"
 
           # Create AMI
-          info "Starting creating AMI"
+          info 'Starting creating AMI'
           new_ami = ec2.create_image(
             block_device_mappings: [
               {
@@ -106,13 +106,13 @@ namespace :deploy do
           info "Finished create AMI #{new_ami.image_id}"
 
           # Create launch template version from new AMI
-          info "Starting create launch template new version"
+          info 'Starting create launch template new version'
           version_name = "Autoscale-#{deployment_env}-template-version-#{date_now}"
 
-          info "Getting launch template data..."
+          info 'Getting launch template data...'
           launch_template_single_version = ec2.describe_launch_template_versions(
             launch_template_id: launch_template_id,
-            versions: ["$Default"]
+            versions: ['$Default']
           ).launch_template_versions.first
           info "- launch template id: #{launch_template_single_version.launch_template_id}"
           info "- launch template chosen version number: #{launch_template_single_version.version_number}"
@@ -131,14 +131,14 @@ namespace :deploy do
               image_id: new_ami.image_id,
               instance_type: fetch(:instance_type),
               iam_instance_profile: {
-                name: iam_instance_profile_name || "autoscaling-iam"
+                name: iam_instance_profile_name || 'autoscaling-iam'
               },
               monitoring: {
                 enabled: true
               },
               security_group_ids: security_groups,
               metadata_options: {
-                instance_metadata_tags: "enabled"
+                instance_metadata_tags: 'enabled'
               },
               ebs_optimized: false
             }
@@ -153,7 +153,7 @@ namespace :deploy do
           info "Finished create launch template new version (V. Number: #{new_template_version_number})"
 
           # Update autoscaling group
-          info "Setting new version as default in the launch template"
+          info 'Setting new version as default in the launch template'
           ec2.modify_launch_template(
             launch_template_id: launch_template_id,
             default_version: new_template_version_number.to_s
@@ -165,7 +165,7 @@ namespace :deploy do
 end
 
 namespace :autoscaled do
-  desc "Autoscale deploy wrapper to deploy standalone or blue/green deploy (with register/deregister instances and ami creation if needed)"
+  desc 'Autoscale deploy wrapper to deploy standalone or blue/green deploy (with register/deregister instances and ami creation if needed)'
   task :deploy do
     stage = fetch(:stage).to_s                 # e.g. "production"
     asg_name = fetch(:autoscaling_group_name)  # set this in deploy/<env>.rb
@@ -185,7 +185,7 @@ namespace :autoscaled do
     invoke 'autoscaled:blue_green_deploy'
   end
 
-  desc "Run blue/green deploy waves using instance_order overrides and LB registration"
+  desc 'Run blue/green deploy waves using instance_order overrides and LB registration'
   task :blue_green_deploy do
     stage = fetch(:stage).to_s
 
@@ -219,7 +219,7 @@ namespace :autoscaled do
 
     # Optionally bake a new AMI after both waves
     if fetch(:blue_green_create_ami, true)
-      puts "Creating new AMI after blue/green deploy..."
+      puts 'Creating new AMI after blue/green deploy...'
       Capistrano::Autoscale::LocalRunner.run_cap_locally(
         stage: stage,
         task_name: 'deploy:new_ami_configuration'

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -14,13 +14,13 @@ namespace :deploy do
 
           autoscaling_group_name = fetch(:autoscaling_group_name)
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
-          tg_arn = autoscaling_group.target_group_arns.first
+          tg_arn = autoscaling_group.target_group_arns&.first
 
-          if tg_arn.present?
-            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
-          else
+          if tg_arn.nil? || tg_arn.empty?
             tg_arn = fetch(:autoscaling_target_group_arn)
             info 'using default target group arn from capistrano config'
+          else
+            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
           end
 
           instances = fetch(:instances)
@@ -48,13 +48,13 @@ namespace :deploy do
 
           autoscaling_group_name = fetch(:autoscaling_group_name)
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
-          tg_arn = autoscaling_group.target_group_arns.first
+          tg_arn = autoscaling_group.target_group_arns&.first
 
-          if tg_arn.present?
-            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
-          else
+          if tg_arn.nil? || tg_arn.empty?
             tg_arn = fetch(:autoscaling_target_group_arn)
             info 'using default target group arn from capistrano config'
+          else
+            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
           end
 
           instances = fetch(:instances)

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -163,3 +163,54 @@ namespace :deploy do
     end
   end
 end
+
+namespace :autoscaled do
+  desc "Autoscale deploy wrapper to deploy standalone or blue/green deploy (with register/deregister instances and ami creation if needed)"
+  task :deploy do
+    stage = fetch(:stage).to_s                 # e.g. "production"
+    asg_name = fetch(:autoscaling_group_name)  # set this in deploy/<env>.rb
+    min_for_blue_green = fetch(:blue_green_min_instances, 2)
+
+    # Determine current instance count from the target group (to select the deploy strategy)
+    ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_all_ec2_instances
+    instance_count = ec2_instances.count
+
+    if instance_count < min_for_blue_green
+      info "ASG #{asg_name} has #{instance_count} instance(s) (min=#{min_for_blue_green}). Running normal deploy on #{stage}."
+      invoke 'deploy' # regular deploy for this env
+      next
+    end
+
+    info "ASG #{asg_name} has #{instance_count} instances, running blue/green deploy."
+    invoke 'autoscaled:blue_green_deploy'
+  end
+
+  desc "Run blue/green deploy waves using instance_order overrides"
+  task :blue_green_deploy do
+    stage = fetch(:stage).to_s
+
+    # Orders to deploy in sequence (default: even then odd)
+    orders = fetch(:blue_green_orders, %w[even odd])
+
+    info "Starting blue/green deploy waves for stage #{stage} (orders: #{orders.join(', ')})"
+
+    orders.each do |order|
+      info "Deploying #{order} instances..."
+      run_locally do
+        with 'INSTANCE_ORDER' => order do
+          execute :bundle, :exec, :cap, stage, 'deploy'
+        end
+      end
+    end
+
+    # Optionally bake a new AMI after both waves
+    if fetch(:blue_green_create_ami, true)
+      info "Creating new AMI after blue/green deploy..."
+      run_locally do
+        execute :bundle, :exec, :cap, stage, 'deploy:new_ami_configuration'
+      end
+    end
+
+    info "Blue/green deploy finished for #{stage}."
+  end
+end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -185,7 +185,7 @@ namespace :autoscaled do
     invoke 'autoscaled:blue_green_deploy'
   end
 
-  desc "Run blue/green deploy waves using instance_order overrides"
+  desc "Run blue/green deploy waves using instance_order overrides and LB registration"
   task :blue_green_deploy do
     stage = fetch(:stage).to_s
 
@@ -196,9 +196,24 @@ namespace :autoscaled do
 
     orders.each do |order|
       info "Deploying #{order} instances..."
+
+      info "Deregistering #{order} instances from load balancer..."
+      run_locally do
+        with 'INSTANCE_ORDER' => order do
+          execute :bundle, :exec, :cap, stage, 'deploy:deregister_instances_from_load_balancer'
+        end
+      end
+
       run_locally do
         with 'INSTANCE_ORDER' => order do
           execute :bundle, :exec, :cap, stage, 'deploy'
+        end
+      end
+
+      info "Registering #{order} instances back into load balancer..."
+      run_locally do
+        with 'INSTANCE_ORDER' => order do
+          execute :bundle, :exec, :cap, stage, 'deploy:register_instances_in_load_balancer'
         end
       end
     end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -9,14 +9,21 @@ namespace :deploy do
 
           loadbalancer = ::Aws::ElasticLoadBalancingV2::Client.new
 
-          instances = fetch(:instances)
-          info "Adding instances #{instances}"
+          autoscaling_group_name = fetch(:autoscaling_group_name)
+          autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
+          tg_arn = autoscaling_group.target_group_arn
 
-          loadbalancer.register_targets(
-              {
-                  target_group_arn: fetch(:autoscaling_target_group_arn),
-                  targets: instances
-              })
+          if tg_arn.present?
+            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
+          else
+            tg_arn = fetch(:autoscaling_target_group_arn)
+            info 'using default target group arn from capistrano config'
+          end
+
+          instances = fetch(:instances)
+          info "Adding instances #{instances} to target group: #{tg_arn}"
+
+          loadbalancer.register_targets(target_group_arn: tg_arn, targets: instances)
           sleep 20
         end
       end
@@ -33,14 +40,21 @@ namespace :deploy do
 
           loadbalancer = ::Aws::ElasticLoadBalancingV2::Client.new
 
-          instances = fetch(:instances)
-          info "Removing instances #{instances}"
+          autoscaling_group_name = fetch(:autoscaling_group_name)
+          autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
+          tg_arn = autoscaling_group.target_group_arn
 
-          loadbalancer.deregister_targets(
-              {
-                  target_group_arn: fetch(:autoscaling_target_group_arn),
-                  targets: instances
-              })
+          if tg_arn.present?
+            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
+          else
+            tg_arn = fetch(:autoscaling_target_group_arn)
+            info 'using default target group arn from capistrano config'
+          end
+
+          instances = fetch(:instances)
+          info "Removing instances #{instances} from target group: #{tg_arn}"
+
+          loadbalancer.deregister_targets(target_group_arn: tg_arn, targets: instances)
         end
       end
     end
@@ -58,17 +72,7 @@ namespace :deploy do
           date_now = Time.now.strftime('%d-%m-%Y %H.%M')
 
           ec2 = ::Aws::EC2::Client.new
-          autoscaling = ::Aws::AutoScaling::Client.new
-          autoscaling_group_name = fetch(:autoscaling_group_name)
-
-          autoscaling_group_response = autoscaling.describe_auto_scaling_groups(
-              {
-                  auto_scaling_group_names: [
-                      autoscaling_group_name
-                  ]
-              }
-          )
-          autoscaling_group = autoscaling_group_response.auto_scaling_groups[0]
+          autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(fetch(:autoscaling_group_name))
           instances = autoscaling_group.instances.map {|h| h['instance_id']}
 
           # Extract launch template ID from autoscaling group

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -91,33 +91,32 @@ namespace :deploy do
           # Create AMI
           info "Starting creating AMI"
           new_ami = ec2.create_image(
+            block_device_mappings: [
               {
-                  block_device_mappings: [
-                      {
-                          device_name: '/dev/sda1',
-                          ebs: {
-                              encrypted: false,
-                              delete_on_termination: true,
-                              volume_size: fetch(:volume_sizes)[0],
-                              volume_type: 'gp2',
-                          }
-                      },
-                      {
-                          device_name: '/dev/sdf',
-                          ebs: {
-                              encrypted: false,
-                              delete_on_termination: true,
-                              volume_size: fetch(:volume_sizes)[1],
-                              volume_type: 'gp2',
-                          }
-                      }
-                  ],
-                  description: "#{deployment_env} autoscale with ebs termination #{date_now}",
-                  dry_run: false,
-                  instance_id: instances.last,
-                  name: "#{deployment_env}-autoscale #{date_now}",
-                  no_reboot: true,
-              })
+                device_name: '/dev/sda1',
+                ebs: {
+                  encrypted: false,
+                  delete_on_termination: true,
+                  volume_size: fetch(:volume_sizes)[0],
+                  volume_type: 'gp2'
+                }
+              },
+              {
+                device_name: '/dev/sdf',
+                ebs: {
+                  encrypted: false,
+                  delete_on_termination: true,
+                  volume_size: fetch(:volume_sizes)[1],
+                  volume_type: 'gp2'
+                }
+              }
+            ],
+            description: "#{deployment_env} autoscale with ebs termination #{date_now}",
+            dry_run: false,
+            instance_id: instances.last,
+            name: "#{deployment_env}-autoscale #{date_now}",
+            no_reboot: true
+          )
           info "Finished create AMI #{new_ami.image_id}"
 
           # Create launch template version from new AMI
@@ -125,10 +124,10 @@ namespace :deploy do
           version_name = "Autoscale-#{deployment_env}-template-version-#{date_now}"
 
           info "Getting launch template data..."
-          launch_template_single_version = ec2.describe_launch_template_versions({
+          launch_template_single_version = ec2.describe_launch_template_versions(
             launch_template_id: launch_template_id,
             versions: ["$Default"]
-          }).launch_template_versions.first
+          ).launch_template_versions.first
           info "- launch template id: #{launch_template_single_version.launch_template_id}"
           info "- launch template chosen version number: #{launch_template_single_version.version_number}"
           security_groups = launch_template_single_version.launch_template_data.security_group_ids
@@ -137,7 +136,7 @@ namespace :deploy do
           info "- launch template versions IAM profile name: #{iam_instance_profile_name}"
           key_name = launch_template_single_version.launch_template_data.key_name
           info "- launch template versions key name: #{key_name}"
-          tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map {|ts| ts.to_h}
+          tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map { |ts| ts.to_h }
 
           lt_request_params = {
             launch_template_id: launch_template_id,
@@ -169,10 +168,10 @@ namespace :deploy do
 
           # Update autoscaling group
           info "Setting new version as default in the launch template"
-          ec2.modify_launch_template({
+          ec2.modify_launch_template(
             launch_template_id: launch_template_id,
             default_version: new_template_version_number.to_s
-          })
+          )
         end
       end
     end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -72,24 +72,7 @@ namespace :deploy do
           instances = autoscaling_group.instances.map {|h| h['instance_id']}
 
           # Extract launch template ID from autoscaling group
-          launch_template_id =
-            if autoscaling_group.launch_template
-              # Try method access first (SDK v1 structure)
-              lt = autoscaling_group.launch_template
-              lt.launch_template_id || lt['launch_template_id'] || lt[:launch_template_id]
-            elsif autoscaling_group['launch_template']
-              # Fallback to hash access
-              lt = autoscaling_group['launch_template']
-              lt['launch_template_id'] || lt[:launch_template_id]
-            else
-              # Fallback to config variable if not found in ASG
-              fetch(:autoscaling_launch_template_id, nil)
-            end
-
-          if launch_template_id.nil?
-            raise "Launch template ID not found in Auto Scaling Group '#{autoscaling_group_name}' and not provided via :autoscaling_launch_template_id config"
-          end
-
+          launch_template_id = Capistrano::Autoscale::AwsUtils.extract_launch_template_id(autoscaling_group)
           info "Using launch template ID: #{launch_template_id}"
 
           # Create AMI

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -68,7 +68,7 @@ namespace :deploy do
 
           ec2 = ::Aws::EC2::Client.new
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(fetch(:autoscaling_group_name))
-          instances = autoscaling_group.instances.map {|h| h['instance_id']}
+          instances = autoscaling_group.instances.map { |h| h['instance_id'] }
 
           # Extract launch template ID from autoscaling group
           launch_template_id = Capistrano::Autoscale::AwsUtils.extract_launch_template_id(autoscaling_group)
@@ -76,81 +76,26 @@ namespace :deploy do
 
           # Create AMI
           info 'Starting creating AMI'
-          new_ami = ec2.create_image(
-            block_device_mappings: [
-              {
-                device_name: '/dev/sda1',
-                ebs: {
-                  encrypted: false,
-                  delete_on_termination: true,
-                  volume_size: fetch(:volume_sizes)[0],
-                  volume_type: 'gp2'
-                }
-              },
-              {
-                device_name: '/dev/sdf',
-                ebs: {
-                  encrypted: false,
-                  delete_on_termination: true,
-                  volume_size: fetch(:volume_sizes)[1],
-                  volume_type: 'gp2'
-                }
-              }
-            ],
-            description: "#{deployment_env} autoscale with ebs termination #{date_now}",
-            dry_run: false,
+          new_ami = Capistrano::Autoscale::AwsUtils.create_ami(
+            ec2: ec2,
             instance_id: instances.last,
-            name: "#{deployment_env}-autoscale #{date_now}",
-            no_reboot: true
+            volume_sizes: fetch(:volume_sizes),
+            deployment_env: deployment_env,
+            date_now: date_now
           )
           info "Finished create AMI #{new_ami.image_id}"
 
           # Create launch template version from new AMI
           info 'Starting create launch template new version'
-          version_name = "Autoscale-#{deployment_env}-template-version-#{date_now}"
-
           info 'Getting launch template data...'
-          launch_template_single_version = ec2.describe_launch_template_versions(
+          new_template_version_number = Capistrano::Autoscale::AwsUtils.create_launch_template_version_from_ami(
+            ec2: ec2,
             launch_template_id: launch_template_id,
-            versions: ['$Default']
-          ).launch_template_versions.first
-          info "- launch template id: #{launch_template_single_version.launch_template_id}"
-          info "- launch template chosen version number: #{launch_template_single_version.version_number}"
-          security_groups = launch_template_single_version.launch_template_data.security_group_ids
-          info "- launch template versions security groups: #{security_groups.join(', ')}"
-          iam_instance_profile_name = launch_template_single_version.launch_template_data.iam_instance_profile&.name
-          info "- launch template versions IAM profile name: #{iam_instance_profile_name}"
-          key_name = launch_template_single_version.launch_template_data.key_name
-          info "- launch template versions key name: #{key_name}"
-          tag_specs = launch_template_single_version.launch_template_data.tag_specifications.map { |ts| ts.to_h }
-
-          lt_request_params = {
-            launch_template_id: launch_template_id,
-            version_description: version_name,
-            launch_template_data: {
-              image_id: new_ami.image_id,
-              instance_type: fetch(:instance_type),
-              iam_instance_profile: {
-                name: iam_instance_profile_name || 'autoscaling-iam'
-              },
-              monitoring: {
-                enabled: true
-              },
-              security_group_ids: security_groups,
-              metadata_options: {
-                instance_metadata_tags: 'enabled'
-              },
-              ebs_optimized: false
-            }
-          }
-          lt_request_params[:launch_template_data][:key_name] = key_name if key_name
-          lt_request_params[:launch_template_data][:tag_specifications] = tag_specs if tag_specs.any?
-          info "- launch template params: #{lt_request_params.to_h}"
-
-          resp = ec2.create_launch_template_version(lt_request_params)
-
-          new_template_version_number = resp.launch_template_version.version_number
-          info "Finished create launch template new version (V. Number: #{new_template_version_number})"
+            image_id: new_ami.image_id,
+            instance_type: fetch(:instance_type),
+            deployment_env: deployment_env,
+            date_now: date_now
+          )
 
           # Update autoscaling group
           info 'Setting new version as default in the launch template'

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -198,32 +198,32 @@ namespace :autoscaled do
       puts "Deploying #{order} instances..."
 
       puts "Deregistering #{order} instances from load balancer..."
-      run_locally do
-        with 'INSTANCE_ORDER' => order do
-          execute :bundle, :exec, :cap, stage, 'deploy:deregister_instances_from_load_balancer'
-        end
-      end
-
-      run_locally do
-        with 'INSTANCE_ORDER' => order do
-          execute :bundle, :exec, :cap, stage, 'deploy'
-        end
-      end
+      Capistrano::Autoscale::LocalRunner.run_cap_locally(
+        stage: stage,
+        task_name: 'deploy:deregister_instances_from_load_balancer',
+        instance_order: order
+      )
+      Capistrano::Autoscale::LocalRunner.run_cap_locally(
+        stage: stage,
+        task_name: 'deploy',
+        instance_order: order
+      )
 
       puts "Registering #{order} instances back into load balancer..."
-      run_locally do
-        with 'INSTANCE_ORDER' => order do
-          execute :bundle, :exec, :cap, stage, 'deploy:register_instances_in_load_balancer'
-        end
-      end
+      Capistrano::Autoscale::LocalRunner.run_cap_locally(
+        stage: stage,
+        task_name: 'deploy:register_instances_in_load_balancer',
+        instance_order: order
+      )
     end
 
     # Optionally bake a new AMI after both waves
     if fetch(:blue_green_create_ami, true)
       puts "Creating new AMI after blue/green deploy..."
-      run_locally do
-        execute :bundle, :exec, :cap, stage, 'deploy:new_ami_configuration'
-      end
+      Capistrano::Autoscale::LocalRunner.run_cap_locally(
+        stage: stage,
+        task_name: 'deploy:new_ami_configuration'
+      )
     end
 
     puts "Blue/green deploy finished for #{stage}."

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -16,13 +16,6 @@ namespace :deploy do
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
           tg_arn = autoscaling_group.target_group_arns&.first
 
-          if tg_arn.nil? || tg_arn.empty?
-            tg_arn = fetch(:autoscaling_target_group_arn)
-            info 'using default target group arn from capistrano config'
-          else
-            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
-          end
-
           instances = fetch(:instances)
           info "Adding instances #{instances} to target group: #{tg_arn}"
 
@@ -49,13 +42,6 @@ namespace :deploy do
           autoscaling_group_name = fetch(:autoscaling_group_name)
           autoscaling_group = Capistrano::Autoscale::AwsUtils.fetch_autoscaling_group(autoscaling_group_name)
           tg_arn = autoscaling_group.target_group_arns&.first
-
-          if tg_arn.nil? || tg_arn.empty?
-            tg_arn = fetch(:autoscaling_target_group_arn)
-            info 'using default target group arn from capistrano config'
-          else
-            info "using target group arn from autoscaling group: #{autoscaling_group_name}"
-          end
 
           instances = fetch(:instances)
           info "Removing instances #{instances} from target group: #{tg_arn}"

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.6'
+    VERSION = '0.3.12-beta.7'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.11-beta.5'
+    VERSION = '0.3.12-beta.1'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.9'
+    VERSION = '0.3.10'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.8'
+    VERSION = '0.4.0'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.10'
+    VERSION = '0.3.11-beta.1'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.7'
+    VERSION = '0.3.12-beta.8'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.1'
+    VERSION = '0.3.12-beta.3'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.4'
+    VERSION = '0.3.12-beta.5'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.11-beta.3'
+    VERSION = '0.3.11-beta.4'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.11-beta.4'
+    VERSION = '0.3.11-beta.5'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.3'
+    VERSION = '0.3.12-beta.4'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.11-beta.1'
+    VERSION = '0.3.11-beta.3'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.3.12-beta.5'
+    VERSION = '0.3.12-beta.6'
   end
 end


### PR DESCRIPTION
## Summary
Refactor y fortalecimiento del flujo de deploy de `capistrano-autoscale` para ambientes single-machine y multi-machine, incorporando una estrategia inteligente que selecciona automáticamente entre deploy normal (directo) y blue/green (por waves). También mejorar la creación de AMI y el versionado de Launch Templates en AWS.

### Impacto
- Deploys más robustos en entornos de una sola máquina y multi-máquina.
- Menor riesgo operativo al versionar Launch Templates sin perder configuración relevante.
- Mejor mantenibilidad por modularización de lógica AWS.
- Flujo blue/green más claro, configurable y reusable.

### Changelog
- Se agrega `autoscaled:deploy` como wrapper que decide la estrategia según cantidad de instancias:
  - Deploy normal cuando no se cumple el mínimo para blue/green.
  - Deploy blue/green cuando hay suficientes instancias.

- Se incorpora `autoscaled:blue_green_deploy` con waves por paridad (`even/odd`), orden configurable (`blue_green_orders`) y opción de crear AMI al finalizar (`blue_green_create_ami`).

- Se mejora el manejo de registro/desregistro en Load Balancer:
  - El Target Group se obtiene dinámicamente desde el ASG.
  - Se elimina dependencia de ARN hardcodeado en configuración.
  - Se agregan logs más claros del flujo.

- Refactor de `AwsUtils` para separar responsabilidades:
  - Configuración AWS.
  - Obtención de ASG.
  - Descubrimiento de instancias EC2 desde Target Group.
  - Creación de AMI.
  - Creación de nueva versión de Launch Template desde AMI.
  - Extracción de Launch Template ID desde ASG/config.

- Se elimina el flujo legacy/deprecado basado en Launch Configuration y se consolida el flujo sobre Launch Templates.

- En nuevas versiones de Launch Template se preserva metadata crítica (incluyendo `user_data`, tags, key name, security groups e IAM profile), evitando pérdida de configuración entre deploys.

- Se agrega `LocalRunner` para ejecutar tareas internas de Capistrano localmente con override de `INSTANCE_ORDER`, facilitando la orquestación blue/green por waves.

- EL metodo `setup_servers` se mejora para:
  - Soportar `INSTANCE_ORDER` por variable de entorno.
  - Normalizar `:instances` usado por tareas de LB.
  - Limpiar asignación de roles y servidor primario.

- Se actualiza README con documentación de instalación, configuración mínima, estrategia de deploy, tareas incluidas y casos especiales (single-node, instancias fuera de ASG pero dentro de TG, orden de waves).