### PR TITLE
[CU-86aeevnk8] Fix: register instances problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,45 @@
 # Capistrano::Autoscale
 
-Herramientas para deploys con Capistrano sobre Auto Scaling Groups en AWS, usando el target group como fuente de servers y soportando deploy normal o blue/green (por paridad `even/odd`).
+Deploy con Capistrano sobre flotas detrás de un **Auto Scaling Group** en AWS: los servers se descubren desde el **target group** ligado al **Auto Scaling Group**, y se usa un solo task que elige entre usar un deploy lineal o **blue/green** (dos waves por paridad de índice).
 
 ## Instalación
 
 En tu `Gemfile`:
+
 ```ruby
 gem 'capistrano-autoscale'
 ```
-Luego:
+
 ```bash
 bundle install
 ```
 
-## Configuración mínima (Capistrano)
+## Configuración (Capistrano)
 
-En `Capfile` (si no lo tienes ya):
+**Capfile** (si aún no lo tienes):
+
 ```ruby
 require 'capistrano/autoscale'
 ```
 
-En `config/deploy.rb` (variables comunes):
+**`config/deploy.rb`** (variables comunes):
+
 ```ruby
-set :aws_region, ENV.fetch('AWS_REGION')                             # required;
-set :aws_access_owner_id, ENV.fetch('AWS_ACCESS_KEY_ID')             # required;
-set :aws_secret_owner_access_key, ENV.fetch('AWS_SECRET_ACCESS_KEY') # required;
-set :autoscaling_group_name, ENV.fetch('AUTOSCALING_GROUP_NAME')     # required;
-set :blue_green_min_instances, 2     # default; mínimo para habilitar blue/green
-set :update_launch_template_ami, true # default; al final de autoscaled:deploy, crear AMI y actualizar launch template
-# Opcional — tras register en el TG, esperar a que todos los targets estén healthy (poll):
+set :aws_region, ENV.fetch('AWS_REGION')
+set :aws_access_owner_id, ENV.fetch('AWS_ACCESS_KEY_ID')
+set :aws_secret_owner_access_key, ENV.fetch('AWS_SECRET_ACCESS_KEY')
+set :autoscaling_group_name, ENV.fetch('AUTOSCALING_GROUP_NAME')
+
+set :blue_green_min_instances, 2       # default; por debajo → deploy sin waves
+set :update_launch_template_ami, true  # default; al final, AMI + nueva versión del launch template
+
+# Tras cada `register_targets`, poll hasta que **todos** los targets del TG estén `healthy`:
 # set :register_poll_interval_sec, 5   # default
-# set :register_poll_timeout_sec, 120  # default; max_attempts = ceil(timeout/interval)
+# set :register_poll_timeout_sec, 120  # default; intentos ≈ ceil(timeout / interval)
 ```
 
-En `config/deploy/production.rb` (ejemplo):
+**`config/deploy/production.rb`** (ejemplo de stage):
+
 ```ruby
 set :rails_env, 'production'      # usualmente ya está seteado
 set :deployment_env, 'production' # required; usado para nombrar la AMI, versión y descripciones
@@ -45,46 +51,75 @@ set :deploy_user, 'ubuntu'        # required;
 setup_servers
 ```
 
-## Cómo se descubren los servers
+Sin `setup_servers` en el stage, Capistrano no tendrá la lista de servers ni `:instances` para las tareas de ELB.
 
-- La gema toma el ARN del target group desde el Auto Scaling Group y lista los targets healthy (`describe_target_health`).
-- Cualquier instance registrada en el target group se incluye, aunque no pertenezca formalmente al ASG (útil para instancias como la cron, o instancias de sidekiq (posiblemente)).
-- Deploy normal (sin la env de IDs de wave): Capistrano usa **todas** las instancias del target group en ese momento.
-- Blue/green: el wrapper toma un snapshot al inicio, parte en dos waves fijas (índices pares luego impares en la lista ordenada por `instance_id`) y pasa la lista fija de IDs a cada subprocess vía variable de entorno interna (`CAP_BLUE_GREEN_INSTANCE_IDS`).
+---
 
-## Deploys
-El deploy funciona a través de un único wrapper task:
+## Uso principal: `autoscaled:deploy`
+
+Este es el **único entrypoint** que debes usar en CI o a mano:
+
 ```bash
-bundle exec cap production autoscaled:deploy
+bundle exec cap <stage> autoscaled:deploy
 ```
 
-Este se adecua a cada caso como vemos a continuación:
+La gema no expone un “modo alternativo” oficial: el resto de tasks existen para componer este flujo o para casos muy puntuales.
 
-### Deploy normal (sin blue/green, menos del "mínimo" de instancias)
-Cuando el target group tiene una sola instance (o cuando no se cumple `blue_green_min_instances`):
-```bash
-bundle exec cap production autoscaled:deploy
-```
-El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal sobre **toda** la flota del TG; al final del wrapper (común a ambas rutas) puede ejecutarse `deploy:new_ami_configuration` según `update_launch_template_ami`.
+### Qué hace, en orden
 
-### Blue/green por paridad
-Con 2 o más instances en el target group, el wrapper:
-1) Cuenta instances del target group.
-2) Si hay suficientes, toma un snapshot de los IDs en el target group, corre dos waves en orden fijo (even luego odd por índice), y para cada subprocess pasa la lista fija de IDs (variable de entorno interna). Así el deregister/deploy/register no depende de un nuevo snapshot del TG entre pasos.
-3) Cuando termina la ruta elegida (deploy normal o blue/green), si `update_launch_template_ami` es true, el wrapper hace `invoke deploy:new_ami_configuration` en el mismo proceso de Capistrano.
+1. **Valida** la configuración del poll de salud tras registrar (`:register_poll_interval_sec` / `:register_poll_timeout_sec` deben ser enteros positivos).
+2. **Toma un snapshot** de la flota: instancias registradas en el target group del ASG (vía `describe_target_health`), ordenadas por `instance_id`. Ese orden fija las waves en blue/green.
+3. **Si no hay ninguna instancia** en el TG → el deploy falla con error explícito.
+4. **Si el número de instancias es menor que `blue_green_min_instances`** (default 2) → ejecuta un **`deploy` normal** sobre **todas** las instancias del snapshot (sin sacar nadie del balanceador).
+5. **Si hay suficientes instancias** → ejecuta **blue/green**:
+   - Parte el snapshot en dos listas: índices **pares** (wave `even`) e **impares** (wave `odd`), en ese orden.
+   - Para **cada** wave, en subprocesos separados de Capistrano (misma variable de entorno interna con los IDs fijos de esa wave):
+     - `deploy:deregister_instances_from_load_balancer` → quita **solo** esas instancias del TG;
+     - `deploy` → despliegue contra **solo** esas instancias;
+     - `deploy:register_instances_in_load_balancer` → vuelve a registrar esas mismas instancias y **espera** a que **todo** el target group esté healthy (poll con timeout).
+   - Así, deregister / deploy / register de una wave **no** dependen de un nuevo listado del TG entre pasos (evita mezclar miembros de waves si el TG cambia entre llamadas).
+6. **Si `update_launch_template_ami` es true** (default) → `deploy:new_ami_configuration`: crea AMI a partir de una instancia del ASG, nueva versión del launch template y la deja como default.
 
-Un `cap ... deploy` directo (sin wrapper) usa toda la flota del TG en ese momento; las waves y los subconjuntos por instancia solo las define el wrapper vía la env de IDs.
+### Deploy “simple” (sin blue/green)
 
-## Tareas incluidas
+Menos de `blue_green_min_instances` instancias en el TG (típico: una sola máquina en QA/staging): un solo `deploy` sobre toda la flota del snapshot, sin deregister/register.
 
-- `autoscaled:deploy`: wrapper que decide normal vs. blue/green según el conteo del target group.
-- `autoscaled:blue_green_deploy`: las dos waves (even, odd); pensado para invocarse desde `autoscaled:deploy` (usa `:all_target_group_instances`). La AMI la dispara solo `autoscaled:deploy` al final si corresponde.
-- `deploy:register_instances_in_load_balancer`: registra los `:instances` en el TG y espera health check (pensado para invocarse desde el flujo `autoscaled:deploy` / blue-green, no como task aislada).
-- `deploy:deregister_instances_from_load_balancer`: los saca del target group.
-- `deploy:new_ami_configuration`: crea AMI desde una instance del ASG, genera nueva versión del Launch Template y la deja como default (requiere `:volume_sizes`, `:instance_type`, `:autoscaling_group_name`).
+### Blue/green (dos waves)
+
+Dos o más instancias en el TG: waves **even** y **odd** según la posición en la lista **ordenada por `instance_id`**. El orden de las waves **no** es configurable (diseño fijo para que los IDs por wave sean estables).
+
+### `cap <stage> deploy` sin el wrapper
+
+Un `deploy` directo **no** ejecuta el wrapper: usa lo que `setup_servers` resuelva en ese momento (toda la flota del TG si no hay env de wave). Las waves y los subconjuntos por instancia las arma **solo** `autoscaled:deploy` / `autoscaled:blue_green_deploy` vía la env interna `CAP_BLUE_GREEN_INSTANCE_IDS` en los subprocesos; **no** hace falta (ni conviene) setearla a mano.
+
+---
+
+## Cómo se descubren las instancias
+
+- El ARN del target group sale del Auto Scaling Group (`target_group_arns.first`).
+- Se consideran **todos** los targets devueltos por `describe_target_health` (no solo los que están `healthy` en ese momento); de ahí se obtienen IDs, se ordenan, y se resuelven IPs con EC2.
+- Cualquier instancia **registrada en el target group** entra en el snapshot, aunque no esté en el ASG (útil para cron, workers, etc., si comparten el mismo TG).
+- En blue/green, **deregister y register** usan exactamente la lista de IDs de la wave actual (`:instances` derivado de `CAP_BLUE_GREEN_INSTANCE_IDS` en cada subproceso).
+
+---
+
+## Otras tareas (referencia)
+
+| Task | Rol |
+|------|-----|
+| `autoscaled:deploy` | **Orquestador** principal (ver arriba). |
+| `autoscaled:blue_green_deploy` | Solo las dos waves; pensado para ser invocado desde `autoscaled:deploy` (requiere `:all_target_group_instances`). |
+| `deploy:deregister_instances_from_load_balancer` | Quita del TG los `:instances` del proceso actual. |
+| `deploy:register_instances_in_load_balancer` | Registra `:instances` en el TG y espera salud global del TG. |
+| `deploy:new_ami_configuration` | AMI + versión de launch template; la invoca el wrapper al final si `update_launch_template_ami`. |
+
+---
 
 ## Casos especiales
-- **Una sola instance**: el deploy normal incluye esa única instancia; el wrapper hará deploy sin waves ni deregistro/registro.
-- **Instance extra fuera del ASG (cron/sidekiq) pero en el target group**: se incluye en el conteo y en las waves porque el discovery se basa en el target group.
+
+- **Una sola instancia**: deploy normal; sin waves ni deregister/register.
+- **Instancias extra en el TG** (p. ej. cron): entran en el conteo y en la partición even/odd como cualquier otro target del TG.
+
 ## Licencia
+
 MIT. See [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ set :aws_access_owner_id, ENV.fetch('AWS_ACCESS_KEY_ID')             # required;
 set :aws_secret_owner_access_key, ENV.fetch('AWS_SECRET_ACCESS_KEY') # required;
 set :autoscaling_group_name, ENV.fetch('AUTOSCALING_GROUP_NAME')     # required;
 set :blue_green_min_instances, 2     # default; mínimo para habilitar blue/green
-set :blue_green_create_ami, true     # default; si quieres crear AMI al final del blue/green
+set :update_launch_template_ami, true # default; al final de autoscaled:deploy, crear AMI y actualizar launch template
 ```
 
 En `config/deploy/production.rb` (ejemplo):
@@ -62,20 +62,20 @@ Cuando el target group tiene una sola instance (o cuando no se cumple `blue_gree
 ```bash
 bundle exec cap production autoscaled:deploy
 ```
-El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal sobre **toda** la flota del TG.
+El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal sobre **toda** la flota del TG; al final del wrapper (común a ambas rutas) puede ejecutarse `deploy:new_ami_configuration` según `update_launch_template_ami`.
 
 ### Blue/green por paridad
 Con 2 o más instances en el target group, el wrapper:
 1) Cuenta instances del target group.
 2) Si hay suficientes, toma un snapshot de los IDs en el target group, corre dos waves en orden fijo (even luego odd por índice), y para cada subprocess pasa la lista fija de IDs (variable de entorno interna). Así el deregister/deploy/register no depende de un nuevo snapshot del TG entre pasos.
-3) Al finalizar las waves, opcionalmente ejecuta `deploy:new_ami_configuration` (controlado por `blue_green_create_ami`).
+3) Cuando termina la ruta elegida (deploy normal o blue/green), si `update_launch_template_ami` es true, el wrapper hace `invoke deploy:new_ami_configuration` en el mismo proceso de Capistrano.
 
 Un `cap ... deploy` directo (sin wrapper) usa toda la flota del TG en ese momento; las waves y los subconjuntos por instancia solo las define el wrapper vía la env de IDs.
 
 ## Tareas incluidas
 
 - `autoscaled:deploy`: wrapper que decide normal vs. blue/green según el conteo del target group.
-- `autoscaled:blue_green_deploy`: las dos waves (even, odd) y AMI opcional; pensado para invocarse desde `autoscaled:deploy` (usa `:all_target_group_instances` que ese task deja con el listado del TG).
+- `autoscaled:blue_green_deploy`: las dos waves (even, odd); pensado para invocarse desde `autoscaled:deploy` (usa `:all_target_group_instances`). La AMI la dispara solo `autoscaled:deploy` al final si corresponde.
 - `deploy:register_instances_in_load_balancer`: registra los `:instances` actuales en el target group.
 - `deploy:deregister_instances_from_load_balancer`: los saca del target group.
 - `deploy:new_ami_configuration`: crea AMI desde una instance del ASG, genera nueva versión del Launch Template y la deja como default (requiere `:volume_sizes`, `:instance_type`, `:autoscaling_group_name`).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ set :aws_secret_owner_access_key, ENV.fetch('AWS_SECRET_ACCESS_KEY') # required;
 set :autoscaling_group_name, ENV.fetch('AUTOSCALING_GROUP_NAME')     # required;
 set :blue_green_min_instances, 2     # default; mínimo para habilitar blue/green
 set :update_launch_template_ami, true # default; al final de autoscaled:deploy, crear AMI y actualizar launch template
+# Opcional — tras register en el TG, esperar a que todos los targets estén healthy (poll):
+# set :register_poll_interval_sec, 5   # default
+# set :register_poll_timeout_sec, 120  # default; max_attempts = ceil(timeout/interval)
 ```
 
 En `config/deploy/production.rb` (ejemplo):
@@ -76,7 +79,7 @@ Un `cap ... deploy` directo (sin wrapper) usa toda la flota del TG en ese moment
 
 - `autoscaled:deploy`: wrapper que decide normal vs. blue/green según el conteo del target group.
 - `autoscaled:blue_green_deploy`: las dos waves (even, odd); pensado para invocarse desde `autoscaled:deploy` (usa `:all_target_group_instances`). La AMI la dispara solo `autoscaled:deploy` al final si corresponde.
-- `deploy:register_instances_in_load_balancer`: registra los `:instances` actuales en el target group.
+- `deploy:register_instances_in_load_balancer`: registra los `:instances` en el TG y espera health check (pensado para invocarse desde el flujo `autoscaled:deploy` / blue-green, no como task aislada).
 - `deploy:deregister_instances_from_load_balancer`: los saca del target group.
 - `deploy:new_ami_configuration`: crea AMI desde una instance del ASG, genera nueva versión del Launch Template y la deja como default (requiere `:volume_sizes`, `:instance_type`, `:autoscaling_group_name`).
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ set :aws_region, ENV.fetch('AWS_REGION')                             # required;
 set :aws_access_owner_id, ENV.fetch('AWS_ACCESS_KEY_ID')             # required;
 set :aws_secret_owner_access_key, ENV.fetch('AWS_SECRET_ACCESS_KEY') # required;
 set :autoscaling_group_name, ENV.fetch('AUTOSCALING_GROUP_NAME')     # required;
-set :instance_order, 'even'          # default; puede ser 'odd' para la otra mitad
 set :blue_green_min_instances, 2     # default; mínimo para habilitar blue/green
-set :blue_green_orders, %w[even odd] # default; secuencia de waves; puedes cambiarla
 set :blue_green_create_ami, true     # default; si quieres crear AMI al final del blue/green
 ```
 
@@ -48,7 +46,8 @@ setup_servers
 
 - La gema toma el ARN del target group desde el Auto Scaling Group y lista los targets healthy (`describe_target_health`).
 - Cualquier instance registrada en el target group se incluye, aunque no pertenezca formalmente al ASG (útil para instancias como la cron, o instancias de sidekiq (posiblemente)).
-- La paridad `even/odd` se aplica por índice del listado ordenado, comenzando en 0.
+- Deploy normal (sin la env de IDs de wave): Capistrano usa **todas** las instancias del target group en ese momento.
+- Blue/green: el wrapper toma un snapshot al inicio, parte en dos waves fijas (índices pares luego impares en la lista ordenada por `instance_id`) y pasa la lista fija de IDs a cada subprocess vía variable de entorno interna (`CAP_BLUE_GREEN_INSTANCE_IDS`).
 
 ## Deploys
 El deploy funciona a través de un único wrapper task:
@@ -63,32 +62,26 @@ Cuando el target group tiene una sola instance (o cuando no se cumple `blue_gree
 ```bash
 bundle exec cap production autoscaled:deploy
 ```
-El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal.
+El wrapper detecta que no hay instancias suficientes y ejecuta `deploy` normal sobre **toda** la flota del TG.
 
 ### Blue/green por paridad
 Con 2 o más instances en el target group, el wrapper:
 1) Cuenta instances del target group.
-2) Si hay suficientes, corre waves en secuencia (`blue_green_orders`, default `even` luego `odd`), pasando `INSTANCE_ORDER` a cada wave. Entre cada wave, va deregistrando/registrando las instancias correspondientes.
+2) Si hay suficientes, toma un snapshot de los IDs en el target group, corre dos waves en orden fijo (even luego odd por índice), y para cada subprocess pasa la lista fija de IDs (variable de entorno interna). Así el deregister/deploy/register no depende de un nuevo snapshot del TG entre pasos.
 3) Al finalizar las waves, opcionalmente ejecuta `deploy:new_ami_configuration` (controlado por `blue_green_create_ami`).
 
-Puedes forzar el orden en runtime:
-```bash
-INSTANCE_ORDER=odd bundle exec cap production deploy
-```
-(Por si quieres correr sólo una wave manualmente.)
+Un `cap ... deploy` directo (sin wrapper) usa toda la flota del TG en ese momento; las waves y los subconjuntos por instancia solo las define el wrapper vía la env de IDs.
 
 ## Tareas incluidas
 
 - `autoscaled:deploy`: wrapper que decide normal vs. blue/green según el conteo del target group.
-- `autoscaled:blue_green_deploy`: ejecuta las waves en el orden configurado y luego la creación de AMI opcional.
+- `autoscaled:blue_green_deploy`: las dos waves (even, odd) y AMI opcional; pensado para invocarse desde `autoscaled:deploy` (usa `:all_target_group_instances` que ese task deja con el listado del TG).
 - `deploy:register_instances_in_load_balancer`: registra los `:instances` actuales en el target group.
 - `deploy:deregister_instances_from_load_balancer`: los saca del target group.
 - `deploy:new_ami_configuration`: crea AMI desde una instance del ASG, genera nueva versión del Launch Template y la deja como default (requiere `:volume_sizes`, `:instance_type`, `:autoscaling_group_name`).
 
 ## Casos especiales
-- **Una sola instance**: usa `instance_order = 'even'` (default) para incluir el índice 0; el wrapper hará deploy normal (sin waves ni deregistro/registro).
+- **Una sola instance**: el deploy normal incluye esa única instancia; el wrapper hará deploy sin waves ni deregistro/registro.
 - **Instance extra fuera del ASG (cron/sidekiq) pero en el target group**: se incluye en el conteo y en las waves porque el discovery se basa en el target group.
-- **Orden de waves**: cambia `blue_green_orders` (ej. `%w[even odd]` o sólo `%w[even]` si quieres evitar un segundo wave en single-node).
-
 ## Licencia
 MIT. See [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/capistrano/autoscale.rb
+++ b/lib/capistrano/autoscale.rb
@@ -4,13 +4,24 @@ require 'aws-sdk-autoscaling'
 require 'capistrano/all'
 require 'capistrano/autoscale/helpers/aws_utils'
 require 'capistrano/autoscale/helpers/local_runner'
+require 'capistrano/autoscale/helpers/blue_green'
 
 load File.expand_path('../autoscale/tasks/autoscale.rake', __FILE__)
 
 def setup_servers
   puts 'Set up instances to deploy for capistrano configuration'
-  instance_order = ENV['INSTANCE_ORDER'] || fetch(:instance_order, 'even')
-  ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_ec2_instances(instance_order)
+  wave_key = Capistrano::Autoscale::BlueGreen::INSTANCE_IDS_ENV
+  wave_ids_env = ENV[wave_key].to_s.strip
+  ec2_instances =
+    if wave_ids_env.empty?
+      all = Capistrano::Autoscale::AwsUtils.fetch_all_ec2_instances
+      puts "Deploy target group fleet: #{all.size} instance(s)"
+      all
+    else
+      ids = wave_ids_env.split(',').map(&:strip).reject(&:empty?)
+      puts "Blue/green wave: #{ids.size} instance(s) from #{wave_key}"
+      Capistrano::Autoscale::AwsUtils.instances_for_ids(ids)
+    end
   aws_deploy_user = fetch(:deploy_user)
 
   # Set up :instances being used (used for deregistering and registering instances in load balancer)

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -2,6 +2,58 @@ module Capistrano
   module Autoscale
     class AwsUtils
       include Capistrano::DSL
+
+      REGISTER_HEALTH_POLL_INTERVAL_DEFAULT = 5
+      REGISTER_HEALTH_POLL_TIMEOUT_DEFAULT = 120
+
+      # Validates poll settings (positive integers); raises if invalid.
+      def self.validate_register_health_poll_config!(interval_sec:, timeout_sec:)
+        interval = Integer(interval_sec)
+        timeout = Integer(timeout_sec)
+        unless interval.positive? && timeout.positive?
+          raise 'Capistrano::Autoscale: :register_poll_interval_sec and ' \
+                ':register_poll_timeout_sec must be positive integers'
+        end
+      rescue ArgumentError, TypeError
+        # Integer() failed (nil, non-numeric string, etc.); re-raise with inputs for easier debugging.
+        raise 'Capistrano::Autoscale: :register_poll_interval_sec / :register_poll_timeout_sec must be positive integers ' \
+              "(got interval=#{interval_sec.inspect} timeout=#{timeout_sec.inspect})"
+      end
+
+      # Poll until every target in the group is +healthy+ (and there is at least one target).
+      # Reads +:register_poll_interval_sec+ and +:register_poll_timeout_sec+ (must be valid; see validate at autoscaled:deploy).
+      # Uses ceil(timeout / interval) attempts (at least 1), sleeping +interval+ between tries.
+      def self.wait_until_target_group_fully_healthy(load_balancer:, target_group_arn:)
+        interval_sec = fetch(:register_poll_interval_sec, REGISTER_HEALTH_POLL_INTERVAL_DEFAULT)
+        timeout_sec = fetch(:register_poll_timeout_sec, REGISTER_HEALTH_POLL_TIMEOUT_DEFAULT)
+        max_attempts = (timeout_sec.to_f / interval_sec.to_f).ceil
+        max_attempts = 1 if max_attempts < 1
+
+        max_attempts.times do |attempt|
+          resp = load_balancer.describe_target_health(target_group_arn: target_group_arn)
+          descs = resp.target_health_descriptions
+          total = descs.size
+          healthy = descs.count { |d| d.target_health.state == 'healthy' }
+
+          if total.positive? && healthy == total
+            puts "Target group: all #{total} target(s) healthy."
+            return
+          end
+
+          puts "Target group health: #{healthy}/#{total} healthy (attempt #{attempt + 1}/#{max_attempts})"
+          if attempt >= max_attempts - 1
+            raise(
+              'Capistrano::Autoscale: target group register health poll timed out ' \
+              "(#{healthy}/#{total} healthy after #{max_attempts} attempts, " \
+              "interval #{interval_sec}s, budget #{timeout_sec}s). " \
+              'Increase :register_poll_timeout_sec or fix targets / checks.'
+            )
+          end
+
+          sleep interval_sec
+        end
+      end
+
       def self.configure_aws(region:, access_key:, secret_key:)
         ::Aws.config[:region] = region
         ::Aws.config[:credentials] = ::Aws::Credentials.new(access_key, secret_key)

--- a/lib/capistrano/autoscale/helpers/aws_utils.rb
+++ b/lib/capistrano/autoscale/helpers/aws_utils.rb
@@ -39,14 +39,28 @@ module Capistrano
         instances_ids.map { |id| instances_by_id[id] }.compact
       end
 
-      def self.fetch_ec2_instances(type)
-        instances = fetch_all_ec2_instances
+      # Resolve IPs for a fixed wave (same order as +instance_ids+). Used when +CAP_BLUE_GREEN_INSTANCE_IDS+ is set.
+      def self.instances_for_ids(instance_ids)
+        ids = Array(instance_ids).map(&:to_s).map(&:strip).reject(&:empty?)
+        return [] if ids.empty?
 
-        selected_instances = instances.values_at(* instances.each_index.select {|i| i.send("#{type}?")})
+        configure_aws(
+          region: fetch(:aws_region),
+          access_key: fetch(:aws_access_owner_id),
+          secret_key: fetch(:aws_secret_owner_access_key)
+        )
 
-        puts "Found #{type} #{selected_instances.count} servers (#{selected_instances.join(',')})"
+        ec2 = ::Aws::EC2::Client.new
+        reservations = ec2.describe_instances(instance_ids: ids).reservations
+        by_id = {}
+        reservations.flat_map(&:instances).each do |i|
+          by_id[i.instance_id] = { instance_id: i.instance_id, private_ip_address: i.private_ip_address }
+        end
 
-        selected_instances
+        ids.map { |id| by_id[id] }.tap do |list|
+          missing = ids - list.compact.map { |h| h[:instance_id] }
+          raise "Could not resolve instance IDs: #{missing.join(', ')}" if missing.any?
+        end
       end
 
       def self.create_ami(ec2:, instance_id:, volume_sizes:, deployment_env:, date_now:)

--- a/lib/capistrano/autoscale/helpers/blue_green.rb
+++ b/lib/capistrano/autoscale/helpers/blue_green.rb
@@ -1,0 +1,44 @@
+module Capistrano
+  module Autoscale
+    # Blue/green: two waves = indices even / odd on the TG snapshot (sorted by instance_id).
+    # Order is fixed (even first, then odd); not configurable — avoids drift from the fixed-ID wave design.
+    module BlueGreen
+      INSTANCE_IDS_ENV = 'CAP_BLUE_GREEN_INSTANCE_IDS'
+
+      # Labels match +Integer#even?+ / +Integer#odd?+ on each index in the snapshot array.
+      WAVE_PARTITION_LABELS = %w[even odd].freeze
+
+      # +all_instances+ as returned by +AwsUtils.fetch_all_ec2_instances+ (ordered list of hashes).
+      def self.instance_ids_by_wave(all_instances)
+        WAVE_PARTITION_LABELS.each_with_object({}) do |label, memo|
+          indices = all_instances.each_index.select { |i| i.send("#{label}?") }
+          memo[label] = all_instances.values_at(*indices).map { |h| h[:instance_id] }
+        end
+      end
+
+      def self.run_wave!(stage:, order:, instance_ids:)
+        puts "Deploying #{order} instances..."
+
+        cap_env = { INSTANCE_IDS_ENV => instance_ids.join(',') }
+
+        puts "Deregistering #{order} instances from load balancer..."
+        LocalRunner.run_cap_locally(
+          stage: stage,
+          task_name: 'deploy:deregister_instances_from_load_balancer',
+          env: cap_env
+        )
+        LocalRunner.run_cap_locally(
+          stage: stage,
+          task_name: 'deploy',
+          env: cap_env
+        )
+        puts "Registering #{order} instances back into load balancer..."
+        LocalRunner.run_cap_locally(
+          stage: stage,
+          task_name: 'deploy:register_instances_in_load_balancer',
+          env: cap_env
+        )
+      end
+    end
+  end
+end

--- a/lib/capistrano/autoscale/helpers/blue_green.rb
+++ b/lib/capistrano/autoscale/helpers/blue_green.rb
@@ -10,6 +10,7 @@ module Capistrano
 
       # +all_instances+ as returned by +AwsUtils.fetch_all_ec2_instances+ (ordered list of hashes).
       def self.instance_ids_by_wave(all_instances)
+        puts "Grouping instances by wave: All instances: #{all_instances.inspect}"
         WAVE_PARTITION_LABELS.each_with_object({}) do |label, memo|
           indices = all_instances.each_index.select { |i| i.send("#{label}?") }
           memo[label] = all_instances.values_at(*indices).map { |h| h[:instance_id] }

--- a/lib/capistrano/autoscale/helpers/local_runner.rb
+++ b/lib/capistrano/autoscale/helpers/local_runner.rb
@@ -1,13 +1,13 @@
 module Capistrano
   module Autoscale
     class LocalRunner
-      def self.run_cap_locally(stage:, task_name:, instance_order: nil)
+      # Runs +bundle exec cap+ locally. Optional +env+ is passed to +system+ (merged into the child process).
+      def self.run_cap_locally(stage:, task_name:, env: nil)
         cmd = ['bundle', 'exec', 'cap', stage.to_s, task_name.to_s]
-        env = {}
-        env['INSTANCE_ORDER'] = instance_order.to_s if instance_order
+        puts "Running locally: #{cmd.join(' ')}"
+        puts "with the env variables: #{env.inspect}" if env&.any?
 
-        puts "Running locally: #{env.empty? ? '' : "INSTANCE_ORDER=#{instance_order} "}#{cmd.join(' ')}"
-        success = system(env, *cmd)
+        success = env&.any? ? system(env, *cmd) : system(*cmd)
         raise "Local command failed: #{cmd.join(' ')}" unless success
       end
     end

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -120,45 +120,47 @@ namespace :autoscaled do
     ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_all_ec2_instances
     instance_count = ec2_instances.count
 
-    if instance_count < min_for_blue_green
-      puts "ASG #{asg_name} has #{instance_count} instance(s) (min=#{min_for_blue_green}). Running normal deploy on #{stage}."
+    if ec2_instances.count.zero?
+      raise 'ERROR: no instances found in target group (with fetch_all_ec2_instances)'
+    elsif instance_count < min_for_blue_green
+      puts "ASG #{asg_name} has #{instance_count} instance(s) (min=#{min_for_blue_green})."
+      puts ">> Running normal deploy on #{stage}."
       invoke 'deploy' # regular deploy for this env
-      next
+    else
+      puts "ASG #{asg_name} has #{instance_count} instances, running blue/green deploy."
+      # Single TG snapshot for this deploy (blue_green_deploy reads it via fetch; Capistrano invoke does not pass kwargs).
+      set :all_target_group_instances, ec2_instances
+      invoke 'autoscaled:blue_green_deploy'
     end
-
-    puts "ASG #{asg_name} has #{instance_count} instances, running blue/green deploy."
-    invoke 'autoscaled:blue_green_deploy'
   end
 
-  desc 'Run blue/green deploy waves using instance_order overrides and LB registration'
+  desc 'Run blue/green deploy waves (fixed instance IDs per wave) and LB registration (invoke via autoscaled:deploy)'
   task :blue_green_deploy do
     stage = fetch(:stage).to_s
 
-    # Orders to deploy in sequence (default: even then odd)
-    orders = fetch(:blue_green_orders, %w[even odd])
+    # TG snapshot from autoscaled:deploy (avoid a second describe_target_health pass).
+    all_instances = fetch(:all_target_group_instances) do
+      raise 'autoscaled:blue_green_deploy is meant to run after autoscaled:deploy ' \
+            '(missing :all_target_group_instances). Call `cap <stage> autoscaled:deploy` instead.'
+    end
+    wave_instance_ids = Capistrano::Autoscale::BlueGreen.instance_ids_by_wave(all_instances)
 
-    puts "Starting blue/green deploy waves for stage #{stage} (orders: #{orders.join(', ')})"
+    puts "Starting blue/green deploy waves for stage #{stage} (even, then odd)"
+    wave_instance_ids.each do |label, ids|
+      puts "  Wave #{label}: #{ids.size} instance(s)"
+    end
 
-    orders.each do |order|
-      puts "Deploying #{order} instances..."
+    Capistrano::Autoscale::BlueGreen::WAVE_PARTITION_LABELS.each do |wave_name|
+      ids = wave_instance_ids[wave_name]
+      if ids.empty?
+        puts "WARNING: Skipping wave #{wave_name}: no instances in the wave list"
+        next
+      end
 
-      puts "Deregistering #{order} instances from load balancer..."
-      Capistrano::Autoscale::LocalRunner.run_cap_locally(
+      Capistrano::Autoscale::BlueGreen.run_wave!(
         stage: stage,
-        task_name: 'deploy:deregister_instances_from_load_balancer',
-        instance_order: order
-      )
-      Capistrano::Autoscale::LocalRunner.run_cap_locally(
-        stage: stage,
-        task_name: 'deploy',
-        instance_order: order
-      )
-
-      puts "Registering #{order} instances back into load balancer..."
-      Capistrano::Autoscale::LocalRunner.run_cap_locally(
-        stage: stage,
-        task_name: 'deploy:register_instances_in_load_balancer',
-        instance_order: order
+        order: wave_name,
+        instance_ids: ids
       )
     end
 

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -20,7 +20,12 @@ namespace :deploy do
           info "Adding instances #{instances} to target group: #{tg_arn}"
 
           loadbalancer.register_targets(target_group_arn: tg_arn, targets: instances)
-          sleep 20
+
+          # Register health poll settings validated at autoscaled:deploy start (this task runs only from that flow).
+          Capistrano::Autoscale::AwsUtils.wait_until_target_group_fully_healthy(
+            load_balancer: loadbalancer,
+            target_group_arn: tg_arn
+          )
         end
       end
     end
@@ -115,6 +120,17 @@ namespace :autoscaled do
     stage = fetch(:stage).to_s                 # e.g. "production"
     asg_name = fetch(:autoscaling_group_name)  # set this in deploy/<env>.rb
     min_for_blue_green = fetch(:blue_green_min_instances, 2)
+
+    Capistrano::Autoscale::AwsUtils.validate_register_health_poll_config!(
+      interval_sec: fetch(
+        :register_poll_interval_sec,
+        Capistrano::Autoscale::AwsUtils::REGISTER_HEALTH_POLL_INTERVAL_DEFAULT
+      ),
+      timeout_sec: fetch(
+        :register_poll_timeout_sec,
+        Capistrano::Autoscale::AwsUtils::REGISTER_HEALTH_POLL_TIMEOUT_DEFAULT
+      )
+    )
 
     # Determine current instance count from the target group (to select the deploy strategy)
     ec2_instances = Capistrano::Autoscale::AwsUtils.fetch_all_ec2_instances

--- a/lib/capistrano/autoscale/tasks/autoscale.rake
+++ b/lib/capistrano/autoscale/tasks/autoscale.rake
@@ -125,12 +125,17 @@ namespace :autoscaled do
     elsif instance_count < min_for_blue_green
       puts "ASG #{asg_name} has #{instance_count} instance(s) (min=#{min_for_blue_green})."
       puts ">> Running normal deploy on #{stage}."
-      invoke 'deploy' # regular deploy for this env
+      invoke 'deploy'
     else
       puts "ASG #{asg_name} has #{instance_count} instances, running blue/green deploy."
       # Single TG snapshot for this deploy (blue_green_deploy reads it via fetch; Capistrano invoke does not pass kwargs).
       set :all_target_group_instances, ec2_instances
       invoke 'autoscaled:blue_green_deploy'
+    end
+
+    if fetch(:update_launch_template_ami, true)
+      puts 'Creating new AMI after deploy...'
+      invoke 'deploy:new_ami_configuration'
     end
   end
 
@@ -145,10 +150,8 @@ namespace :autoscaled do
     end
     wave_instance_ids = Capistrano::Autoscale::BlueGreen.instance_ids_by_wave(all_instances)
 
-    puts "Starting blue/green deploy waves for stage #{stage} (even, then odd)"
-    wave_instance_ids.each do |label, ids|
-      puts "  Wave #{label}: #{ids.size} instance(s)"
-    end
+    puts ">>> Starting blue/green deploy waves for stage #{stage} (even, then odd)"
+    puts "Grouped instances by wave: #{wave_instance_ids.inspect}"
 
     Capistrano::Autoscale::BlueGreen::WAVE_PARTITION_LABELS.each do |wave_name|
       ids = wave_instance_ids[wave_name]
@@ -161,15 +164,6 @@ namespace :autoscaled do
         stage: stage,
         order: wave_name,
         instance_ids: ids
-      )
-    end
-
-    # Optionally bake a new AMI after both waves
-    if fetch(:blue_green_create_ami, true)
-      puts 'Creating new AMI after blue/green deploy...'
-      Capistrano::Autoscale::LocalRunner.run_cap_locally(
-        stage: stage,
-        task_name: 'deploy:new_ami_configuration'
       )
     end
 

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end

--- a/lib/capistrano/autoscale/version.rb
+++ b/lib/capistrano/autoscale/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Autoscale
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end


### PR DESCRIPTION
### Summary
Mejoras sobre el nuevo proceso de deploy autoescalado
Ahora el register instances espera y revisa que las instancias se registre correctamente entre cada paso antes de continuar con el deploy.
Tambien el manejo de las instancias pares e inpares se hace internamente dentro de los wrappers de capistrano-autoscale